### PR TITLE
don't check for the existence of a 'normalized file' if the file exists

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu May 07 11:26:33 CEST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/gov/loc/repository/bagit/verify/CheckIfFileExistsTask.java
+++ b/src/main/java/gov/loc/repository/bagit/verify/CheckIfFileExistsTask.java
@@ -31,11 +31,10 @@ public class CheckIfFileExistsTask implements Runnable {
 
   @Override
   public void run() {
-    final boolean existsNormalized = existsNormalized();
     final boolean fileExists = Files.exists(file);
     
     if(!fileExists){
-      if(existsNormalized){
+      if(existsNormalized()){
         logger.warn(messages.getString("different_normalization_on_filesystem_warning"), file);
       }
       else{


### PR DESCRIPTION
Checking the existence of the 'normalized file' is quite expensive and often not necessary. This PR moves the call to `existsNormalized()` to a later point such that is isn't required to run if not necessary.

@DANS-KNAW/easy for review