### PR TITLE
Dd 1328

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - DD-1328
   pull_request:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,8 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-site-report
           restore-keys: |
             ${{ runner.os }}-maven-
-
       - name: Generate reports and publish reports
         run: mvn -B clean test site jacoco:report coveralls:report --file pom.xml -DrepoToken=${{ secrets.COVERALLS_REPO_TOKEN }} -Djarsigner.skip=true
-
       - name: Generate pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - DD-1316
+      - DD-1328
   pull_request:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-site-report
           restore-keys: |
             ${{ runner.os }}-maven-
 


### PR DESCRIPTION
Fixes DD-1328

# Description of changes

Adds a new cache key for the site build and reporting. This is because the site generation downloads a whole set of extra pom files (from dependencies) and several dependencies it needs itself before generating the site. The cache is created before in a previous step that does not download all these dependencies. Unfortunately the cache is immutable; once created it will not be updated. 

So the simplest solution is to use a new cache just for the reporting step. 

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
