### PR TITLE
DD-2219 Handle multi-line and long bag-info.txt values

### DIFF
--- a/src/integration/java/nl/knaw/dans/bagit/BagitSuiteComplanceTest.java
+++ b/src/integration/java/nl/knaw/dans/bagit/BagitSuiteComplanceTest.java
@@ -15,20 +15,10 @@
  */
 package nl.knaw.dans.bagit;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicLong;
-
+import nl.knaw.dans.bagit.conformance.BagLinter;
+import nl.knaw.dans.bagit.conformance.BagitWarning;
 import nl.knaw.dans.bagit.domain.Bag;
+import nl.knaw.dans.bagit.domain.Version;
 import nl.knaw.dans.bagit.exceptions.CorruptChecksumException;
 import nl.knaw.dans.bagit.exceptions.FileNotInPayloadDirectoryException;
 import nl.knaw.dans.bagit.exceptions.InvalidBagitFileFormatException;
@@ -39,167 +29,177 @@ import nl.knaw.dans.bagit.exceptions.MissingPayloadManifestException;
 import nl.knaw.dans.bagit.exceptions.UnparsableVersionException;
 import nl.knaw.dans.bagit.exceptions.UnsupportedAlgorithmException;
 import nl.knaw.dans.bagit.exceptions.VerificationException;
+import nl.knaw.dans.bagit.reader.BagReader;
 import nl.knaw.dans.bagit.verify.BagVerifier;
+import nl.knaw.dans.bagit.writer.BagWriter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import nl.knaw.dans.bagit.conformance.BagLinter;
-import nl.knaw.dans.bagit.conformance.BagitWarning;
-import nl.knaw.dans.bagit.domain.Version;
-import nl.knaw.dans.bagit.reader.BagReader;
-import nl.knaw.dans.bagit.writer.BagWriter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * This class assumes that the compliance test suite repo has been cloned and is available locally
  */
 public class BagitSuiteComplanceTest extends TempFolderTest {
-  private static final Logger logger = LoggerFactory.getLogger(BagitSuiteComplanceTest.class);
-  
-  private static final Path complianceRepoRootDir = Paths.get("bagit-conformance-suite");
-  private static final BagTestCaseVistor visitor = new BagTestCaseVistor();
-  private static final BagReader reader = new BagReader();
-  private static final BagVerifier verifier = new BagVerifier();
-  
-  @BeforeAll
-  public static void setupOnce() throws IOException{
-    if(!Files.exists(complianceRepoRootDir)){
-      throw new IOException("bagit-conformance-suite git repo was not found, did you clone it?");
-    }
-    Files.walkFileTree(complianceRepoRootDir, visitor);
-  }
-  
-  @Test
-  public void testValidBags() throws Exception{
-    Bag bag;
-    
-    for(final Path bagDir : visitor.getValidTestCases()){
-      bag = reader.read(bagDir);
-      verifier.isValid(bag, true);
-    }
-  }
-  
-  @Test
-  public void testInvalidBags(){
-    int errorCount = 0;
-    Bag bag;
-    ConcurrentMap<Class<? extends Exception>, AtomicLong> map = new ConcurrentHashMap<>();
-    
-    for(Path invalidBagDir : visitor.getInvalidTestCases()){
-      try{
-        bag = reader.read(invalidBagDir);
-        verifier.isValid(bag, true);
-        System.err.println(bag.getRootDir() + " should have failed but didn't!");
-      }catch(InvalidBagitFileFormatException | IOException | UnparsableVersionException |
-             MissingPayloadManifestException | MissingBagitFileException | MissingPayloadDirectoryException |
-             FileNotInPayloadDirectoryException | InterruptedException | MaliciousPathException |
-             CorruptChecksumException | VerificationException | UnsupportedAlgorithmException e){
-        
-        logger.info("Found invalid os specific bag with message: {}", e.getMessage());
-        map.putIfAbsent(e.getClass(), new AtomicLong(0));
-        map.get(e.getClass()).incrementAndGet();
-        errorCount++;
-      }
-    }
-    
-    Assertions.assertEquals(visitor.getInvalidTestCases().size(), errorCount, "every test case should throw an error");
-    logger.debug("Count of all errors found in generic invalid cases: {}", map);
-  }
-  
-  @Test
-  public void testInvalidOperatingSystemSpecificBags(){
-    int errorCount = 0;
-    Bag bag;
-    List<Path> osSpecificInvalidPaths = visitor.getLinuxOnlyTestCases();
-    ConcurrentMap<Class<? extends Exception>, AtomicLong> map = new ConcurrentHashMap<>();
-    
-    if(TestUtils.isExecutingOnWindows()){
-      osSpecificInvalidPaths = visitor.getWindowsOnlyTestCases();
-    }
-    
-    for(Path invalidBagDir : osSpecificInvalidPaths){
-      try{
-        bag = reader.read(invalidBagDir);
-        verifier.isValid(bag, true);
-      }catch(InvalidBagitFileFormatException | IOException | UnparsableVersionException | 
-        MissingPayloadManifestException | MissingBagitFileException | MissingPayloadDirectoryException | 
-        FileNotInPayloadDirectoryException | InterruptedException | MaliciousPathException | 
-        CorruptChecksumException | VerificationException | UnsupportedAlgorithmException e){
+    private static final Logger logger = LoggerFactory.getLogger(BagitSuiteComplanceTest.class);
 
-        logger.info("Found invalid os specific bag with message: {}", e.getMessage());
-        map.putIfAbsent(e.getClass(), new AtomicLong(0));
-        map.get(e.getClass()).incrementAndGet();
-        errorCount++;
-      }
+    private static final Path complianceRepoRootDir = Paths.get("bagit-conformance-suite");
+    private static final BagTestCaseVistor visitor = new BagTestCaseVistor();
+    private static final BagReader reader = new BagReader();
+    private static final BagVerifier verifier = new BagVerifier();
+
+    @BeforeAll
+    public static void setupOnce() throws IOException {
+        if (!Files.exists(complianceRepoRootDir)) {
+            throw new IOException("bagit-conformance-suite git repo was not found, did you clone it?");
+        }
+        Files.walkFileTree(complianceRepoRootDir, visitor);
     }
-    
-    Assertions.assertEquals(osSpecificInvalidPaths.size(), errorCount, "every test case should throw an error");
-    logger.debug("Count of all errors found in os specific invalid cases: {}", map);
-  }
-  
-  @Test
-  public void testWarnings() throws Exception{
-    Set<BagitWarning> warnings;
-    
-    for(Path bagDir : visitor.getWarningTestCases()){
-      warnings = BagLinter.lintBag(bagDir);
-        Assertions.assertFalse(warnings.isEmpty());
+
+    @Test
+    public void testValidBags() throws Exception {
+        Bag bag;
+
+        for (final Path bagDir : visitor.getValidTestCases()) {
+            bag = reader.read(bagDir);
+            verifier.isValid(bag, true);
+        }
     }
-  }
-  
-  @Test
-  public void testReadWriteProducesSameBag() throws Exception{
-    Bag bag;
-    Path newBagDir;
-    
-    for(final Path bagDir : visitor.getValidTestCases()){
-      newBagDir = folder.resolve("readWriteProducesSameBag");
-      bag = reader.read(bagDir);
-      BagWriter.write(bag, newBagDir);
-      
-      testTagFileContents(bag, newBagDir);
-      
-      testBagsStructureAreEqual(bagDir, newBagDir);
-      delete(newBagDir);
+
+    @Test
+    public void testInvalidBags() {
+        int errorCount = 0;
+        Bag bag;
+        ConcurrentMap<Class<? extends Exception>, AtomicLong> map = new ConcurrentHashMap<>();
+
+        for (Path invalidBagDir : visitor.getInvalidTestCases()) {
+            try {
+                bag = reader.read(invalidBagDir);
+                verifier.isValid(bag, true);
+                System.err.println(bag.getRootDir() + " should have failed but didn't!");
+            }
+            catch (InvalidBagitFileFormatException | IOException | UnparsableVersionException |
+                   MissingPayloadManifestException | MissingBagitFileException | MissingPayloadDirectoryException |
+                   FileNotInPayloadDirectoryException | InterruptedException | MaliciousPathException |
+                   CorruptChecksumException | VerificationException | UnsupportedAlgorithmException e) {
+
+                logger.info("Found invalid os specific bag with message: {}", e.getMessage());
+                map.putIfAbsent(e.getClass(), new AtomicLong(0));
+                map.get(e.getClass()).incrementAndGet();
+                errorCount++;
+            }
+        }
+
+        Assertions.assertEquals(visitor.getInvalidTestCases().size(), errorCount, "every test case should throw an error");
+        logger.debug("Count of all errors found in generic invalid cases: {}", map);
     }
-  }
-  
-  private void testTagFileContents(final Bag originalBag, final Path newBagDir) throws IOException{
-    Path original = originalBag.getRootDir().resolve("bagit.txt");
-    Path newFile = newBagDir.resolve("bagit.txt");
-    Assertions.assertTrue(compareFileContents(original, newFile, StandardCharsets.UTF_8), "bagit.txt files differ");
-    
-    if(originalBag.getVersion().isSameOrOlder(new Version(0, 95))){
-      original = originalBag.getRootDir().resolve("package-info.txt");
-      newFile = newBagDir.resolve("package-info.txt");
-      Assertions.assertTrue(compareFileContents(original, newFile, originalBag.getFileEncoding()), 
-          original + " differs from " + newFile);
+
+    @Test
+    public void testInvalidOperatingSystemSpecificBags() {
+        int errorCount = 0;
+        Bag bag;
+        List<Path> osSpecificInvalidPaths = visitor.getLinuxOnlyTestCases();
+        ConcurrentMap<Class<? extends Exception>, AtomicLong> map = new ConcurrentHashMap<>();
+
+        if (TestUtils.isExecutingOnWindows()) {
+            osSpecificInvalidPaths = visitor.getWindowsOnlyTestCases();
+        }
+
+        for (Path invalidBagDir : osSpecificInvalidPaths) {
+            try {
+                bag = reader.read(invalidBagDir);
+                verifier.isValid(bag, true);
+            }
+            catch (InvalidBagitFileFormatException | IOException | UnparsableVersionException |
+                   MissingPayloadManifestException | MissingBagitFileException | MissingPayloadDirectoryException |
+                   FileNotInPayloadDirectoryException | InterruptedException | MaliciousPathException |
+                   CorruptChecksumException | VerificationException | UnsupportedAlgorithmException e) {
+
+                logger.info("Found invalid os specific bag with message: {}", e.getMessage());
+                map.putIfAbsent(e.getClass(), new AtomicLong(0));
+                map.get(e.getClass()).incrementAndGet();
+                errorCount++;
+            }
+        }
+
+        Assertions.assertEquals(osSpecificInvalidPaths.size(), errorCount, "every test case should throw an error");
+        logger.debug("Count of all errors found in os specific invalid cases: {}", map);
     }
-    else{
-      if(Files.exists(originalBag.getRootDir().resolve("bag-info.txt"))){
-        original = originalBag.getRootDir().resolve("bag-info.txt");
-        newFile = newBagDir.resolve("bag-info.txt");
-        Assertions.assertTrue(compareFileContents(original,newFile, originalBag.getFileEncoding()),
-            original + " differs from " + newFile);
-      }
+
+    @Test
+    public void testWarnings() throws Exception {
+        Set<BagitWarning> warnings;
+
+        for (Path bagDir : visitor.getWarningTestCases()) {
+            warnings = BagLinter.lintBag(bagDir);
+            Assertions.assertFalse(warnings.isEmpty());
+        }
     }
-    
-  }
-  
-  //return true if the content is the same disregarding line endings and indentation
-  private boolean compareFileContents(final Path file1, final Path file2, final Charset encoding) throws IOException {
-    List<String> lines1 = Files.readAllLines(file1, encoding);
-    List<String> lines2 = Files.readAllLines(file2, encoding);
-    
-    String s1 = String.join("", lines1).replaceAll("\\r|\\n| |\t", "").replaceAll("Payload-Oxum:[0-9.]+", "");
-    String s2 = String.join("", lines2).replaceAll("\\r|\\n| |\t", "").replaceAll("Payload-Oxum:[0-9.]+", "");
-    
-    return s1.equals(s2);
-  }
-  
-  private void testBagsStructureAreEqual(Path originalBag, Path newBag) throws IOException{
-    Files.walkFileTree(originalBag, new FileExistsVistor(originalBag, newBag));
-  }
+
+    @Test
+    public void testReadWriteProducesSameBag() throws Exception {
+        Bag bag;
+        Path newBagDir;
+
+        for (final Path bagDir : visitor.getValidTestCases()) {
+            newBagDir = folder.resolve("readWriteProducesSameBag");
+            bag = reader.read(bagDir);
+            BagWriter.write(bag, newBagDir);
+
+            testTagFileContents(bag, newBagDir);
+
+            testBagsStructureAreEqual(bagDir, newBagDir);
+            delete(newBagDir);
+        }
+    }
+
+    private void testTagFileContents(final Bag originalBag, final Path newBagDir) throws IOException {
+        Path original = originalBag.getRootDir().resolve("bagit.txt");
+        Path newFile = newBagDir.resolve("bagit.txt");
+        Assertions.assertTrue(compareFileContents(original, newFile, StandardCharsets.UTF_8), "bagit.txt files differ");
+
+        if (originalBag.getVersion().isSameOrOlder(new Version(0, 95))) {
+            original = originalBag.getRootDir().resolve("package-info.txt");
+            newFile = newBagDir.resolve("package-info.txt");
+            Assertions.assertTrue(compareFileContents(original, newFile, originalBag.getFileEncoding()),
+                original + " differs from " + newFile);
+        }
+        else {
+            if (Files.exists(originalBag.getRootDir().resolve("bag-info.txt"))) {
+                original = originalBag.getRootDir().resolve("bag-info.txt");
+                newFile = newBagDir.resolve("bag-info.txt");
+                Assertions.assertTrue(compareFileContents(original, newFile, originalBag.getFileEncoding()),
+                    original + " differs from " + newFile);
+            }
+        }
+
+    }
+
+    //return true if the content is the same disregarding line endings and indentation
+    private boolean compareFileContents(final Path file1, final Path file2, final Charset encoding) throws IOException {
+        List<String> lines1 = Files.readAllLines(file1, encoding);
+        List<String> lines2 = Files.readAllLines(file2, encoding);
+
+        String s1 = String.join("", lines1).replaceAll("\\r|\\n| |\t", "").replaceAll("Payload-Oxum:[0-9.]+", "");
+        String s2 = String.join("", lines2).replaceAll("\\r|\\n| |\t", "").replaceAll("Payload-Oxum:[0-9.]+", "");
+
+        return s1.equals(s2);
+    }
+
+    private void testBagsStructureAreEqual(Path originalBag, Path newBag) throws IOException {
+        Files.walkFileTree(originalBag, new FileExistsVistor(originalBag, newBag));
+    }
 }

--- a/src/integration/java/nl/knaw/dans/bagit/BagitSuiteComplanceTest.java
+++ b/src/integration/java/nl/knaw/dans/bagit/BagitSuiteComplanceTest.java
@@ -145,7 +145,7 @@ public class BagitSuiteComplanceTest extends TempFolderTest {
     
     for(Path bagDir : visitor.getWarningTestCases()){
       warnings = BagLinter.lintBag(bagDir);
-      Assertions.assertTrue(warnings.size() > 0);
+        Assertions.assertFalse(warnings.isEmpty());
     }
   }
   
@@ -188,8 +188,8 @@ public class BagitSuiteComplanceTest extends TempFolderTest {
     
   }
   
-  //return true if the content is the same disregarding line endings
-  private final boolean compareFileContents(final Path file1, final Path file2, final Charset encoding) throws IOException {
+  //return true if the content is the same disregarding line endings and indentation
+  private boolean compareFileContents(final Path file1, final Path file2, final Charset encoding) throws IOException {
     List<String> lines1 = Files.readAllLines(file1, encoding);
     List<String> lines2 = Files.readAllLines(file2, encoding);
     

--- a/src/integration/java/nl/knaw/dans/bagit/BagitSuiteComplanceTest.java
+++ b/src/integration/java/nl/knaw/dans/bagit/BagitSuiteComplanceTest.java
@@ -193,15 +193,10 @@ public class BagitSuiteComplanceTest extends TempFolderTest {
     List<String> lines1 = Files.readAllLines(file1, encoding);
     List<String> lines2 = Files.readAllLines(file2, encoding);
     
-    List<String> strippedLines1 = new ArrayList<>(lines1.size());
-    List<String> strippedLines2 = new ArrayList<>(lines2.size());
+    String s1 = String.join("", lines1).replaceAll("\\r|\\n| |\t", "").replaceAll("Payload-Oxum:[0-9.]+", "");
+    String s2 = String.join("", lines2).replaceAll("\\r|\\n| |\t", "").replaceAll("Payload-Oxum:[0-9.]+", "");
     
-    for(int index=0; index<lines1.size(); index++){
-      strippedLines1.add(lines1.get(index).replaceAll("\\r|\\n| ", ""));
-      strippedLines2.add(lines2.get(index).replaceAll("\\r|\\n| ", ""));
-    }
-    
-    return strippedLines1.containsAll(strippedLines2);
+    return s1.equals(s2);
   }
   
   private void testBagsStructureAreEqual(Path originalBag, Path newBag) throws IOException{

--- a/src/main/java/nl/knaw/dans/bagit/reader/KeyValueReader.java
+++ b/src/main/java/nl/knaw/dans/bagit/reader/KeyValueReader.java
@@ -83,7 +83,8 @@ public final class KeyValueReader {
   
   private static void mergeIndentedLine(final String line, final List<SimpleImmutableEntry<String, String>> keyValues){
     final SimpleImmutableEntry<String, String> oldKeyValue = keyValues.remove(keyValues.size() -1);
-    final SimpleImmutableEntry<String, String> newKeyValue = new SimpleImmutableEntry<>(oldKeyValue.getKey(), oldKeyValue.getValue() + System.lineSeparator() +line);
+    final String newContent = line.substring(1);
+    final SimpleImmutableEntry<String, String> newKeyValue = new SimpleImmutableEntry<>(oldKeyValue.getKey(), oldKeyValue.getValue() + System.lineSeparator() + newContent);
     keyValues.add(newKeyValue);
     
     logger.debug(messages.getString("found_indented_line"), oldKeyValue.getKey());

--- a/src/main/java/nl/knaw/dans/bagit/reader/KeyValueReader.java
+++ b/src/main/java/nl/knaw/dans/bagit/reader/KeyValueReader.java
@@ -83,7 +83,7 @@ public final class KeyValueReader {
   
   private static void mergeIndentedLine(final String line, final List<SimpleImmutableEntry<String, String>> keyValues){
     final SimpleImmutableEntry<String, String> oldKeyValue = keyValues.remove(keyValues.size() -1);
-    final String newContent = line.substring(1);
+    final String newContent = line.stripLeading();
     final SimpleImmutableEntry<String, String> newKeyValue = new SimpleImmutableEntry<>(oldKeyValue.getKey(), oldKeyValue.getValue() + System.lineSeparator() + newContent);
     keyValues.add(newKeyValue);
     

--- a/src/main/java/nl/knaw/dans/bagit/writer/MetadataWriter.java
+++ b/src/main/java/nl/knaw/dans/bagit/writer/MetadataWriter.java
@@ -93,7 +93,7 @@ public final class MetadataWriter {
       final int maxLength = i == 0 ? 79 - keyPrefixLength : 78; // Continuation lines have " " prefix
       // Check if it's already "well-wrapped" or short
       if (line.length() > maxLength) {
-        sb.append(wrapLine(line, i == 0, i > 0, keyPrefixLength));
+        sb.append(wrapLine(line, i == 0, keyPrefixLength));
       } else {
         sb.append(line);
       }
@@ -101,7 +101,7 @@ public final class MetadataWriter {
     return sb.toString();
   }
 
-  private static String wrapLine(final String line, final boolean isFirstLine, final boolean startsWithNewline, final int keyPrefixLength) {
+  private static String wrapLine(final String line, final boolean isFirstLine, final int keyPrefixLength) {
     final StringBuilder sb = new StringBuilder();
     int start = 0;
     boolean firstWrap = true;
@@ -122,7 +122,7 @@ public final class MetadataWriter {
       }
       
       String sub = line.substring(start, end);
-      if (start > 0 || (firstWrap && startsWithNewline)) {
+      if (start > 0) {
         sb.append(System.lineSeparator());
         sb.append(" ");
       }

--- a/src/main/java/nl/knaw/dans/bagit/writer/MetadataWriter.java
+++ b/src/main/java/nl/knaw/dans/bagit/writer/MetadataWriter.java
@@ -61,12 +61,80 @@ public final class MetadataWriter {
     final StringBuilder lines = new StringBuilder();
     
     for(final SimpleImmutableEntry<String, String> entry : metadata.getAll()){
-      final String line = entry.getKey() + ": " + entry.getValue() + System.lineSeparator();
-      lines.append(line);
+      final String key = entry.getKey();
+      String value = entry.getValue();
+      value = value.replaceAll("[^\\x09\\x20-\\x7E\\x0A\\x0D\\x80-\\uFFFF]", "");
+      lines.append(formatLine(key, value, version)).append(System.lineSeparator());
     }
     
     logger.debug(messages.getString("writing_line_to_file"), lines.toString(), bagInfoFilePath);
     Files.write(bagInfoFilePath, lines.toString().getBytes(charsetName), 
         StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+  }
+
+  private static String formatLine(final String key, final String value, final Version version) {
+    if (version.isSameOrOlder(VERSION_0_95)) {
+      final String fullLine = key + ": " + value;
+      return fullLine.replaceAll("(\\r\\n|\\r|\\n)", "$1 ");
+    }
+    
+    final StringBuilder sb = new StringBuilder();
+    final int keyPrefixLength = key.length() + 2; // "Key: "
+    sb.append(key).append(": ");
+    final String[] parts = value.split("(\\r\\n|\\r|\\n)", -1);
+    
+    for (int i = 0; i < parts.length; i++) {
+      String line = parts[i];
+      if (i > 0) {
+        sb.append(System.lineSeparator());
+        line = " " + line;
+      }
+      
+      final int maxLength = i == 0 ? 79 - keyPrefixLength : 78; // Continuation lines have " " prefix
+      // Check if it's already "well-wrapped" or short
+      if (line.length() > maxLength) {
+        sb.append(wrapLine(line, i == 0, i > 0, keyPrefixLength));
+      } else {
+        sb.append(line);
+      }
+    }
+    return sb.toString();
+  }
+
+  private static String wrapLine(final String line, final boolean isFirstLine, final boolean startsWithNewline, final int keyPrefixLength) {
+    final StringBuilder sb = new StringBuilder();
+    int start = 0;
+    boolean firstWrap = true;
+    
+    while (start < line.length()) {
+      int maxLength = 78; // Indented line starts with " ", so 78 more chars = 79
+      if (firstWrap && isFirstLine) {
+        maxLength = 79 - keyPrefixLength;
+      }
+      
+      int end = Math.min(start + maxLength, line.length());
+      
+      if (end < line.length()) {
+        int lastSpace = line.lastIndexOf(' ', end);
+        if (lastSpace > start) {
+          end = lastSpace;
+        }
+      }
+      
+      String sub = line.substring(start, end);
+      if (start > 0 || (firstWrap && startsWithNewline)) {
+        sb.append(System.lineSeparator());
+        sb.append(" ");
+      }
+      sb.append(sub);
+      
+      start = end;
+      while (start < line.length() && line.charAt(start) == ' ') {
+        start++;
+      }
+      firstWrap = false;
+    }
+    
+    return sb.toString();
   }
 }

--- a/src/test/java/nl/knaw/dans/bagit/reader/MetadataReaderTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/reader/MetadataReaderTest.java
@@ -44,7 +44,7 @@ public class MetadataReaderTest extends PrivateConstructorTest {
     expectedValues.add(new SimpleImmutableEntry<>("Contact-Phone", "+1 408-555-1212"));
     expectedValues.add(new SimpleImmutableEntry<>("Contact-Email", "ej@spengler.edu"));
     expectedValues.add(new SimpleImmutableEntry<>("External-Description", "Uncompressed greyscale TIFF images from the" + System.lineSeparator() + 
-        "         Yoshimuri papers collection."));
+        "        Yoshimuri papers collection."));
     expectedValues.add(new SimpleImmutableEntry<>("Bagging-Date", "2008-01-15"));
     expectedValues.add(new SimpleImmutableEntry<>("External-Identifier", "spengler_yoshimuri_001"));
     expectedValues.add(new SimpleImmutableEntry<>("Bag-Size", "260 GB"));
@@ -52,7 +52,7 @@ public class MetadataReaderTest extends PrivateConstructorTest {
     expectedValues.add(new SimpleImmutableEntry<>("Bag-Count", "1 of 15"));
     expectedValues.add(new SimpleImmutableEntry<>("Internal-Sender-Identifier", "/storage/images/yoshimuri"));
     expectedValues.add(new SimpleImmutableEntry<>("Internal-Sender-Description", "Uncompressed greyscale TIFFs created from" + System.lineSeparator() + 
-        "         microfilm."));
+        "        microfilm."));
     expectedValues.add(new SimpleImmutableEntry<>("Bag-Count", "1 of 15")); //test duplicate
     
     Path bagInfoFile = Paths.get(getClass().getClassLoader().getResource("baginfoFiles").toURI());

--- a/src/test/java/nl/knaw/dans/bagit/reader/MetadataReaderTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/reader/MetadataReaderTest.java
@@ -44,7 +44,7 @@ public class MetadataReaderTest extends PrivateConstructorTest {
     expectedValues.add(new SimpleImmutableEntry<>("Contact-Phone", "+1 408-555-1212"));
     expectedValues.add(new SimpleImmutableEntry<>("Contact-Email", "ej@spengler.edu"));
     expectedValues.add(new SimpleImmutableEntry<>("External-Description", "Uncompressed greyscale TIFF images from the" + System.lineSeparator() + 
-        "        Yoshimuri papers collection."));
+        "Yoshimuri papers collection."));
     expectedValues.add(new SimpleImmutableEntry<>("Bagging-Date", "2008-01-15"));
     expectedValues.add(new SimpleImmutableEntry<>("External-Identifier", "spengler_yoshimuri_001"));
     expectedValues.add(new SimpleImmutableEntry<>("Bag-Size", "260 GB"));
@@ -52,7 +52,7 @@ public class MetadataReaderTest extends PrivateConstructorTest {
     expectedValues.add(new SimpleImmutableEntry<>("Bag-Count", "1 of 15"));
     expectedValues.add(new SimpleImmutableEntry<>("Internal-Sender-Identifier", "/storage/images/yoshimuri"));
     expectedValues.add(new SimpleImmutableEntry<>("Internal-Sender-Description", "Uncompressed greyscale TIFFs created from" + System.lineSeparator() + 
-        "        microfilm."));
+        "microfilm."));
     expectedValues.add(new SimpleImmutableEntry<>("Bag-Count", "1 of 15")); //test duplicate
     
     Path bagInfoFile = Paths.get(getClass().getClassLoader().getResource("baginfoFiles").toURI());

--- a/src/test/java/nl/knaw/dans/bagit/writer/MetadataWriterTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/writer/MetadataWriterTest.java
@@ -27,6 +27,9 @@ import org.junit.jupiter.api.Test;
 
 import nl.knaw.dans.bagit.domain.Metadata;
 import nl.knaw.dans.bagit.domain.Version;
+import nl.knaw.dans.bagit.reader.KeyValueReader;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.List;
 
 public class MetadataWriterTest extends PrivateConstructorTest {
   
@@ -53,5 +56,95 @@ public class MetadataWriterTest extends PrivateConstructorTest {
     
     MetadataWriter.writeBagMetadata(metadata, new Version(0,95), rootDir, StandardCharsets.UTF_8);
     Assertions.assertTrue(Files.exists(packageInfo));
+  }
+
+  @Test
+  public void testWriteAndReadMultilineMetadata() throws Exception {
+    Path rootDir = createDirectory("multilineTest");
+    Metadata metadata = new Metadata();
+    String multilineValue = "This is a" + System.lineSeparator() + "multi-line" + System.lineSeparator() + "value.";
+    metadata.add("Description", multilineValue);
+    metadata.add("Contact-Name", "John Doe");
+
+    MetadataWriter.writeBagMetadata(metadata, new Version(1, 0), rootDir, StandardCharsets.UTF_8);
+
+    Path bagInfo = rootDir.resolve("bag-info.txt");
+    String content = Files.readString(bagInfo, StandardCharsets.UTF_8);
+
+    // Check if subsequent lines are indented
+    String[] lines = content.split("\\R");
+    Assertions.assertTrue(lines[0].startsWith("Description: "));
+    Assertions.assertTrue(lines[1].startsWith(" "), "Line 2 should be indented");
+    Assertions.assertTrue(lines[2].startsWith(" "), "Line 3 should be indented");
+
+    // Read it back
+    List<SimpleImmutableEntry<String, String>> readMetadata = KeyValueReader.readKeyValuesFromFile(bagInfo, ":", StandardCharsets.UTF_8);
+    
+    boolean foundDescription = false;
+    for (SimpleImmutableEntry<String, String> entry : readMetadata) {
+      if ("Description".equals(entry.getKey())) {
+        Assertions.assertEquals(multilineValue, entry.getValue());
+        foundDescription = true;
+      }
+    }
+    Assertions.assertTrue(foundDescription);
+  }
+
+  @Test
+  public void testSanitizeMetadata() throws Exception {
+    Path rootDir = createDirectory("sanitizeTest");
+    Metadata metadata = new Metadata();
+    // \u0000 is a non-printable char, \u0007 is bell
+    String dirtyValue = "Value with\u0000 non-printable\u0007 chars.";
+    String cleanValue = "Value with non-printable chars.";
+    metadata.add("Custom-Key", dirtyValue);
+
+    MetadataWriter.writeBagMetadata(metadata, new Version(1, 0), rootDir, StandardCharsets.UTF_8);
+
+    Path bagInfo = rootDir.resolve("bag-info.txt");
+    List<SimpleImmutableEntry<String, String>> readMetadata = KeyValueReader.readKeyValuesFromFile(bagInfo, ":", StandardCharsets.UTF_8);
+    
+    for (SimpleImmutableEntry<String, String> entry : readMetadata) {
+      if ("Custom-Key".equals(entry.getKey())) {
+        Assertions.assertEquals(cleanValue, entry.getValue());
+      }
+    }
+  }
+
+  @Test
+  public void testWrapLongLines() throws Exception {
+    Path rootDir = createDirectory("wrapLongLinesTest");
+    Metadata metadata = new Metadata();
+    String longValue = "This is a very long value that should definitely exceed the seventy-nine characters limit that is recommended by the BagIt RFC 8493 section two point two point two.";
+    // Length is ~166 chars.
+    metadata.add("Long-Key", longValue);
+
+    MetadataWriter.writeBagMetadata(metadata, new Version(1, 0), rootDir, StandardCharsets.UTF_8);
+
+    Path bagInfo = rootDir.resolve("bag-info.txt");
+    String content = Files.readString(bagInfo, StandardCharsets.UTF_8);
+
+    String[] lines = content.split("\\R");
+    for (String line : lines) {
+      Assertions.assertTrue(line.length() <= 80, "Line length should be <= 80 (79 chars + potential newline): " + line.length());
+      if (!line.startsWith("Long-Key: ")) {
+        Assertions.assertTrue(line.startsWith(" "), "Wrapped lines should be indented");
+      }
+    }
+
+    // Read it back
+    List<SimpleImmutableEntry<String, String>> readMetadata = KeyValueReader.readKeyValuesFromFile(bagInfo, ":", StandardCharsets.UTF_8);
+    boolean foundLongKey = false;
+    for (SimpleImmutableEntry<String, String> entry : readMetadata) {
+      if ("Long-Key".equals(entry.getKey())) {
+        String expectedValue = longValue.replace(" ", System.lineSeparator());
+        // Since it's wrapped at spaces, the space is replaced by newline in reading if it's joined by newline
+        // But wrapLine also preserves spaces? Let's check what it actually produces.
+        // It should match the longValue with some spaces replaced by newlines.
+        Assertions.assertEquals(longValue, entry.getValue().replace(System.lineSeparator(), " "));
+        foundLongKey = true;
+      }
+    }
+    Assertions.assertTrue(foundLongKey);
   }
 }

--- a/src/test/java/nl/knaw/dans/bagit/writer/MetadataWriterTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/writer/MetadataWriterTest.java
@@ -31,6 +31,8 @@ import nl.knaw.dans.bagit.reader.KeyValueReader;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class MetadataWriterTest extends PrivateConstructorTest {
   
   @Test
@@ -52,10 +54,10 @@ public class MetadataWriterTest extends PrivateConstructorTest {
     Assertions.assertFalse(Files.exists(packageInfo));
     
     MetadataWriter.writeBagMetadata(metadata, new Version(0,96), rootDir, StandardCharsets.UTF_8);
-    Assertions.assertTrue(Files.exists(bagInfo));
+    assertTrue(Files.exists(bagInfo));
     
     MetadataWriter.writeBagMetadata(metadata, new Version(0,95), rootDir, StandardCharsets.UTF_8);
-    Assertions.assertTrue(Files.exists(packageInfo));
+    assertTrue(Files.exists(packageInfo));
   }
 
   @Test
@@ -73,9 +75,9 @@ public class MetadataWriterTest extends PrivateConstructorTest {
 
     // Check if subsequent lines are indented
     String[] lines = content.split("\\R");
-    Assertions.assertTrue(lines[0].startsWith("Description: "));
-    Assertions.assertTrue(lines[1].startsWith(" "), "Line 2 should be indented");
-    Assertions.assertTrue(lines[2].startsWith(" "), "Line 3 should be indented");
+    assertTrue(lines[0].startsWith("Description: "));
+    assertTrue(lines[1].startsWith(" "), "Line 2 should be indented");
+    assertTrue(lines[2].startsWith(" "), "Line 3 should be indented");
 
     // Read it back
     List<SimpleImmutableEntry<String, String>> readMetadata = KeyValueReader.readKeyValuesFromFile(bagInfo, ":", StandardCharsets.UTF_8);
@@ -87,7 +89,7 @@ public class MetadataWriterTest extends PrivateConstructorTest {
         foundDescription = true;
       }
     }
-    Assertions.assertTrue(foundDescription);
+    assertTrue(foundDescription);
   }
 
   @Test
@@ -103,12 +105,15 @@ public class MetadataWriterTest extends PrivateConstructorTest {
 
     Path bagInfo = rootDir.resolve("bag-info.txt");
     List<SimpleImmutableEntry<String, String>> readMetadata = KeyValueReader.readKeyValuesFromFile(bagInfo, ":", StandardCharsets.UTF_8);
-    
+
+    boolean found = false;
     for (SimpleImmutableEntry<String, String> entry : readMetadata) {
       if ("Custom-Key".equals(entry.getKey())) {
         Assertions.assertEquals(cleanValue, entry.getValue());
+        found = true;
       }
     }
+    assertTrue(found);
   }
 
   @Test
@@ -126,9 +131,9 @@ public class MetadataWriterTest extends PrivateConstructorTest {
 
     String[] lines = content.split("\\R");
     for (String line : lines) {
-      Assertions.assertTrue(line.length() <= 80, "Line length should be <= 80 (79 chars + potential newline): " + line.length());
+      assertTrue(line.length() <= 79, "Line length should be <= 79: " + line.length());
       if (!line.startsWith("Long-Key: ")) {
-        Assertions.assertTrue(line.startsWith(" "), "Wrapped lines should be indented");
+        assertTrue(line.startsWith(" "), "Wrapped lines should be indented");
       }
     }
 
@@ -137,7 +142,6 @@ public class MetadataWriterTest extends PrivateConstructorTest {
     boolean foundLongKey = false;
     for (SimpleImmutableEntry<String, String> entry : readMetadata) {
       if ("Long-Key".equals(entry.getKey())) {
-        String expectedValue = longValue.replace(" ", System.lineSeparator());
         // Since it's wrapped at spaces, the space is replaced by newline in reading if it's joined by newline
         // But wrapLine also preserves spaces? Let's check what it actually produces.
         // It should match the longValue with some spaces replaced by newlines.
@@ -145,7 +149,7 @@ public class MetadataWriterTest extends PrivateConstructorTest {
         foundLongKey = true;
       }
     }
-    Assertions.assertTrue(foundLongKey);
+    assertTrue(foundLongKey);
   }
 
   @Test
@@ -156,10 +160,10 @@ public class MetadataWriterTest extends PrivateConstructorTest {
     String value = "Short first line\nThis is a very long second line that will definitely need wrapping because it's much longer than seventy-nine characters.";
     metadata.add("Description", value);
 
-    MetadataWriter.writeBagMetadata(metadata, new Version(1, 0), rootDir, java.nio.charset.StandardCharsets.UTF_8);
+    MetadataWriter.writeBagMetadata(metadata, new Version(1, 0), rootDir, StandardCharsets.UTF_8);
 
     Path bagInfo = rootDir.resolve("bag-info.txt");
-    String content = Files.readString(bagInfo, java.nio.charset.StandardCharsets.UTF_8);
+    String content = Files.readString(bagInfo, StandardCharsets.UTF_8);
 
     // Check for double newlines or lines containing only a space
     String[] lines = content.split("\\r?\\n");
@@ -168,7 +172,7 @@ public class MetadataWriterTest extends PrivateConstructorTest {
       Assertions.assertFalse(line.isEmpty() && i < lines.length - 1, "Should not have empty lines in the middle (caused by double newlines)");
       if (i > 0) {
         // All lines after the first one of an entry must be indented
-        Assertions.assertTrue(line.startsWith(" "), "Continuation line must start with a space: [" + line + "]");
+        assertTrue(line.startsWith(" "), "Continuation line must start with a space: [" + line + "]");
         // If it was a double newline, we'd see a line that is just " " followed by another line
         Assertions.assertNotEquals(" ", line, "Should not have a line that is just a single space");
       }

--- a/src/test/java/nl/knaw/dans/bagit/writer/MetadataWriterTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/writer/MetadataWriterTest.java
@@ -147,4 +147,31 @@ public class MetadataWriterTest extends PrivateConstructorTest {
     }
     Assertions.assertTrue(foundLongKey);
   }
+
+  @Test
+  public void testMultilineAndWrapping() throws Exception {
+    Path rootDir = createDirectory("multilineAndWrappingTest");
+    Metadata metadata = new Metadata();
+    // A multiline value where the first line is short and the second is long
+    String value = "Short first line\nThis is a very long second line that will definitely need wrapping because it's much longer than seventy-nine characters.";
+    metadata.add("Description", value);
+
+    MetadataWriter.writeBagMetadata(metadata, new Version(1, 0), rootDir, java.nio.charset.StandardCharsets.UTF_8);
+
+    Path bagInfo = rootDir.resolve("bag-info.txt");
+    String content = Files.readString(bagInfo, java.nio.charset.StandardCharsets.UTF_8);
+
+    // Check for double newlines or lines containing only a space
+    String[] lines = content.split("\\r?\\n");
+    for (int i = 0; i < lines.length; i++) {
+      String line = lines[i];
+      Assertions.assertFalse(line.isEmpty() && i < lines.length - 1, "Should not have empty lines in the middle (caused by double newlines)");
+      if (i > 0) {
+        // All lines after the first one of an entry must be indented
+        Assertions.assertTrue(line.startsWith(" "), "Continuation line must start with a space: [" + line + "]");
+        // If it was a double newline, we'd see a line that is just " " followed by another line
+        Assertions.assertNotEquals(" ", line, "Should not have a line that is just a single space");
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes DD-2219

# Description of changes
According to the BagIt specs multi-line values in `bag-info.txt` should be continued with an indent on the next line. See: https://www.rfc-editor.org/rfc/rfc8493#section-2.2.2. This was previously not implemented correctly leading to invalid bags.

# Notify

@DANS-KNAW/core-systems
