### PR TITLE
DD-2203 Holey bagit validation

### DIFF
--- a/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
+++ b/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
@@ -82,12 +82,37 @@ public final class Hasher {
    * @throws IOException if there is a problem reading from the URL
    */
   public static String hash(final URL url, final MessageDigest messageDigest) throws IOException {
+    return hash(url, messageDigest, null);
+  }
+
+  /**
+   * Create a HEX formatted string checksum hash of the data from the URL
+   *
+   * @param url the {@link URL} to hash
+   * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
+   * @param extraHeaders optional extra headers to send with the request
+   * @return the hash as a hex formatted string
+   * @throws IOException if there is a problem reading from the URL
+   */
+  public static String hash(final URL url, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
     long totalSize = -1;
     boolean rangeSupported = false;
     URLConnection connection = url.openConnection();
 
     if (connection instanceof HttpURLConnection httpConnection) {
       httpConnection.setRequestMethod("HEAD");
+      httpConnection.setInstanceFollowRedirects(true);
+      if (extraHeaders != null) {
+        for (Entry<String, String> entry : extraHeaders.entrySet()) {
+          httpConnection.setRequestProperty(entry.getKey(), entry.getValue());
+        }
+      }
+
+      int responseCode = httpConnection.getResponseCode();
+      if (responseCode >= 300 && responseCode < 400) {
+        String newUrl = httpConnection.getHeaderField("Location");
+        return hash(new URL(newUrl), messageDigest, extraHeaders);
+      }
 
       totalSize = httpConnection.getContentLengthLong();
       String acceptRanges = httpConnection.getHeaderField("Accept-Ranges");
@@ -96,10 +121,19 @@ public final class Hasher {
 
     if (rangeSupported && totalSize > 0) {
       logger.info("Range requests supported for {}, downloading in chunks", url);
-      hashWithRangeRequests(url, messageDigest, totalSize);
+      hashWithRangeRequests(url, messageDigest, totalSize, extraHeaders);
     } else {
       logger.info("Range requests NOT supported or size unknown for {}, downloading full stream", url);
-      try (final InputStream is = new BufferedInputStream(url.openStream())) {
+      URLConnection conn = url.openConnection();
+      if (conn instanceof HttpURLConnection httpConn) {
+        httpConn.setInstanceFollowRedirects(true);
+        if (extraHeaders != null) {
+          for (Entry<String, String> entry : extraHeaders.entrySet()) {
+            httpConn.setRequestProperty(entry.getKey(), entry.getValue());
+          }
+        }
+      }
+      try (final InputStream is = new BufferedInputStream(conn.getInputStream())) {
         final byte[] buffer = new byte[CHUNK_SIZE];
         int read = is.read(buffer);
 
@@ -113,7 +147,7 @@ public final class Hasher {
     return formatMessageDigest(messageDigest);
   }
 
-  private static void hashWithRangeRequests(final URL url, final MessageDigest messageDigest, final long totalSize) throws IOException {
+  private static void hashWithRangeRequests(final URL url, final MessageDigest messageDigest, final long totalSize, final Map<String, String> extraHeaders) throws IOException {
     long chunkSize = Long.getLong(CHUNK_SIZE_PROP, DEFAULT_CHUNK_SIZE);
     int maxRetries = Integer.getInteger(MAX_RETRIES_PROP, DEFAULT_MAX_RETRIES);
     int retrySleepMs = Integer.getInteger(RETRY_SLEEP_MS_PROP, DEFAULT_RETRY_SLEEP_MS);
@@ -122,7 +156,7 @@ public final class Hasher {
     while (offset < totalSize) {
       long end = Math.min(offset + chunkSize - 1, totalSize - 1);
       String range = "bytes=" + offset + "-" + end;
-      int bytesRead = executeWithRetries(url, range, messageDigest, maxRetries, retrySleepMs);
+      int bytesRead = executeWithRetries(url, range, messageDigest, maxRetries, retrySleepMs, extraHeaders);
       if (bytesRead < 0) {
         throw new IOException("Failed to fetch range " + range + " after " + maxRetries + " attempts");
       }
@@ -133,10 +167,10 @@ public final class Hasher {
   /**
    * Executes the ranged request with retry logic. Returns the number of bytes read, or -1 if all retries failed.
    */
-  private static int executeWithRetries(URL url, String range, MessageDigest messageDigest, int maxRetries, int retrySleepMs) throws IOException {
+  private static int executeWithRetries(URL url, String range, MessageDigest messageDigest, int maxRetries, int retrySleepMs, final Map<String, String> extraHeaders) throws IOException {
     for (int attempt = 0; attempt < maxRetries; attempt++) {
       try {
-        HttpURLConnection conn = openRangedConnection(url, range);
+        HttpURLConnection conn = openRangedConnection(url, range, extraHeaders);
         int code = conn.getResponseCode();
         if (code != 206 && code != 200) {
           throw new IOException("Unexpected response code " + code + " for range " + range);
@@ -164,8 +198,14 @@ public final class Hasher {
   /**
    * Opens a HttpURLConnection for the given range.
    */
-  private static HttpURLConnection openRangedConnection(URL url, String range) throws IOException {
+  private static HttpURLConnection openRangedConnection(URL url, String range, final Map<String, String> extraHeaders) throws IOException {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setInstanceFollowRedirects(true);
+    if (extraHeaders != null) {
+      for (Entry<String, String> entry : extraHeaders.entrySet()) {
+        conn.setRequestProperty(entry.getKey(), entry.getValue());
+      }
+    }
     conn.setRequestProperty("Range", range);
     return conn;
   }

--- a/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
+++ b/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
@@ -168,6 +168,7 @@ public final class Hasher {
             }
             catch (IOException e) {
                 logger.info("Falling back to full stream for {} after failed range requests", currentUrl);
+                messageDigest.reset();
                 return hashFullStream(currentUrl, messageDigest, currentHeaders);
             }
         }

--- a/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
+++ b/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
@@ -18,6 +18,7 @@ package nl.knaw.dans.bagit.hash;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,6 +45,14 @@ public final class Hasher {
   private static final int _64_KB = 1024 * 64;
   private static final int CHUNK_SIZE = _64_KB;
   private static final ResourceBundle messages = ResourceBundle.getBundle("MessageBundle");
+
+  private static final String CHUNK_SIZE_PROP = "nl.knaw.dans.bagit.hash.chunkSize";
+  private static final String MAX_RETRIES_PROP = "nl.knaw.dans.bagit.hash.maxRetries";
+  private static final String RETRY_SLEEP_MS_PROP = "nl.knaw.dans.bagit.hash.retrySleepMs";
+
+  private static final long DEFAULT_CHUNK_SIZE = 1024L * 1024L; // 1 MiB
+  private static final int DEFAULT_MAX_RETRIES = 5;
+  private static final int DEFAULT_RETRY_SLEEP_MS = 5000;
   
   private Hasher(){
     //intentionally left empty
@@ -72,17 +81,89 @@ public final class Hasher {
    * @throws IOException if there is a problem reading from the URL
    */
   public static String hash(final URL url, final MessageDigest messageDigest) throws IOException {
-    try (final InputStream is = new BufferedInputStream(url.openStream())) {
-      final byte[] buffer = new byte[CHUNK_SIZE];
-      int read = is.read(buffer);
+    long totalSize = -1;
+    boolean rangeSupported = false;
+    java.net.URLConnection connection = url.openConnection();
 
-      while (read != -1) {
-        messageDigest.update(buffer, 0, read);
-        read = is.read(buffer);
+    if (connection instanceof HttpURLConnection) {
+      HttpURLConnection httpConnection = (HttpURLConnection) connection;
+      httpConnection.setRequestMethod("HEAD");
+      int responseCode = httpConnection.getResponseCode();
+
+      totalSize = httpConnection.getContentLengthLong();
+      String acceptRanges = httpConnection.getHeaderField("Accept-Ranges");
+      rangeSupported = "bytes".equalsIgnoreCase(acceptRanges);
+    }
+
+    if (rangeSupported && totalSize > 0) {
+      logger.info("Range requests supported for {}, downloading in chunks", url);
+      hashWithRangeRequests(url, messageDigest, totalSize);
+    } else {
+      logger.info("Range requests NOT supported or size unknown for {}, downloading full stream", url);
+      try (final InputStream is = new BufferedInputStream(url.openStream())) {
+        final byte[] buffer = new byte[CHUNK_SIZE];
+        int read = is.read(buffer);
+
+        while (read != -1) {
+          messageDigest.update(buffer, 0, read);
+          read = is.read(buffer);
+        }
       }
     }
 
     return formatMessageDigest(messageDigest);
+  }
+
+  private static void hashWithRangeRequests(final URL url, final MessageDigest messageDigest, final long totalSize) throws IOException {
+    long chunkSize = Long.getLong(CHUNK_SIZE_PROP, DEFAULT_CHUNK_SIZE);
+    int maxRetries = Integer.getInteger(MAX_RETRIES_PROP, DEFAULT_MAX_RETRIES);
+    int retrySleepMs = Integer.getInteger(RETRY_SLEEP_MS_PROP, DEFAULT_RETRY_SLEEP_MS);
+
+    long offset = 0;
+    while (offset < totalSize) {
+      long end = Math.min(offset + chunkSize - 1, totalSize - 1);
+      String range = "bytes=" + offset + "-" + end;
+      
+      boolean success = false;
+      for (int attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+          conn.setRequestProperty("Range", range);
+          int code = conn.getResponseCode();
+          
+          if (code != 206 && code != 200) {
+             throw new IOException("Unexpected response code " + code + " for range " + range);
+          }
+          
+          try (InputStream is = conn.getInputStream()) {
+            byte[] buffer = new byte[CHUNK_SIZE];
+            int read = is.read(buffer);
+            while (read != -1) {
+              messageDigest.update(buffer, 0, read);
+              offset += read;
+              read = is.read(buffer);
+            }
+          }
+          success = true;
+          break;
+        } catch (IOException e) {
+          logger.warn("Error fetching range {} (attempt {}/{}): {}", range, attempt + 1, maxRetries, e.getMessage());
+          if (attempt < maxRetries - 1) {
+            try {
+              Thread.sleep(retrySleepMs);
+            } catch (InterruptedException ie) {
+              Thread.currentThread().interrupt();
+              throw new IOException("Interrupted during retry sleep", ie);
+            }
+          } else {
+            throw e;
+          }
+        }
+      }
+      if (!success) {
+        throw new IOException("Failed to fetch range " + range + " after " + maxRetries + " attempts");
+      }
+    }
   }
   
   /**

--- a/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
+++ b/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
@@ -15,6 +15,11 @@
  */
 package nl.knaw.dans.bagit.hash;
 
+import nl.knaw.dans.bagit.domain.FetchItem;
+import nl.knaw.dans.bagit.domain.Manifest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,342 +31,383 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Formatter;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.ResourceBundle;
 import java.util.Map.Entry;
-
-import nl.knaw.dans.bagit.domain.FetchItem;
-import nl.knaw.dans.bagit.domain.Manifest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.ResourceBundle;
 
 /**
- * Convenience class for generating a HEX formatted string of the checksum hash. 
+ * Convenience class for generating a HEX formatted string of the checksum hash.
  */
 public final class Hasher {
-  private static final Logger logger = LoggerFactory.getLogger(Hasher.class);
-  private static final int _64_KB = 1024 * 64;
-  private static final int CHUNK_SIZE = _64_KB;
-  private static final ResourceBundle messages = ResourceBundle.getBundle("MessageBundle");
+    private static final Logger logger = LoggerFactory.getLogger(Hasher.class);
+    private static final int _64_KB = 1024 * 64;
+    private static final int CHUNK_SIZE = _64_KB;
+    private static final ResourceBundle messages = ResourceBundle.getBundle("MessageBundle");
 
-  private static final String CHUNK_SIZE_PROP = "nl.knaw.dans.bagit.hash.chunkSize";
-  private static final String MAX_RETRIES_PROP = "nl.knaw.dans.bagit.hash.maxRetries";
-  private static final String RETRY_SLEEP_MS_PROP = "nl.knaw.dans.bagit.hash.retrySleepMs";
+    private static final String CHUNK_SIZE_PROP = "nl.knaw.dans.bagit.hash.chunkSize";
+    private static final String MAX_RETRIES_PROP = "nl.knaw.dans.bagit.hash.maxRetries";
+    private static final String RETRY_SLEEP_MS_PROP = "nl.knaw.dans.bagit.hash.retrySleepMs";
 
-  private static final long DEFAULT_CHUNK_SIZE = 500 * 1024L * 1024L; // 1 MiB
-  private static final int DEFAULT_MAX_RETRIES = 5;
-  private static final int DEFAULT_RETRY_SLEEP_MS = 5000;
-  
-  private Hasher(){
-    //intentionally left empty
-  }
-  
-  /**
-   * Create a HEX formatted string checksum hash of the file
-   * 
-   * @param path the {@link Path} (file) to hash
-   * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
-   * @return the hash as a hex formated string
-   * @throws IOException if there is a problem reading the file
-   */
-  public static String hash(final Path path, final MessageDigest messageDigest) throws IOException {
-    updateMessageDigests(path, Arrays.asList(messageDigest));
-    
-    return formatMessageDigest(messageDigest);
-  }
+    private static final long DEFAULT_CHUNK_SIZE = 1024L * 1024L * 1024L; // 1 GiB
+    private static final int DEFAULT_MAX_RETRIES = 5;
+    private static final int DEFAULT_RETRY_SLEEP_MS = 5000;
 
-  /**
-   * Create a HEX formatted string checksum hash of the data from the URL
-   *
-   * @param url the {@link URL} to hash
-   * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
-   * @return the hash as a hex formatted string
-   * @throws IOException if there is a problem reading from the URL
-   */
-  public static String hash(final URL url, final MessageDigest messageDigest) throws IOException {
-    return hash(url, messageDigest, null);
-  }
-
-  /**
-   * Create a HEX formatted string checksum hash of the data from the {@link FetchItem}
-   *
-   * @param item the {@link FetchItem} to hash
-   * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
-   * @param extraHeaders optional extra headers to send with the request
-   * @return the hash as a hex formatted string
-   * @throws IOException if there is a problem reading from the URL
-   */
-  public static String hash(final FetchItem item, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
-    long totalSize = (item.length != null && item.length >= 0) ? item.length : -1;
-    URL currentUrl = item.url;
-    Map<String, String> currentHeaders = extraHeaders;
-
-    if (!currentUrl.getProtocol().startsWith("http")) {
-      return hashFullStream(currentUrl, messageDigest, currentHeaders);
+    private Hasher() {
+        //intentionally left empty
     }
 
-    long chunkSize = Long.getLong(CHUNK_SIZE_PROP, DEFAULT_CHUNK_SIZE);
-    int maxRetries = Integer.getInteger(MAX_RETRIES_PROP, DEFAULT_MAX_RETRIES);
-    int retrySleepMs = Integer.getInteger(RETRY_SLEEP_MS_PROP, DEFAULT_RETRY_SLEEP_MS);
+    /**
+     * Create a HEX formatted string checksum hash of the file
+     *
+     * @param path          the {@link Path} (file) to hash
+     * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
+     * @return the hash as a hex formated string
+     * @throws IOException if there is a problem reading the file
+     */
+    public static String hash(final Path path, final MessageDigest messageDigest) throws IOException {
+        updateMessageDigests(path, Collections.singletonList(messageDigest));
 
-    long offset = 0;
-    while (totalSize < 0 || offset < totalSize) {
-      long end = (totalSize > 0) ? Math.min(offset + chunkSize - 1, totalSize - 1) : offset + chunkSize - 1;
-      String range = "bytes=" + offset + "-" + end;
+        return formatMessageDigest(messageDigest);
+    }
 
-      boolean retryChunk = false;
-      for (int attempt = 0; attempt < maxRetries; attempt++) {
-        try {
-          HttpURLConnection conn = openRangedConnection(currentUrl, range, currentHeaders);
-          int code = conn.getResponseCode();
+    /**
+     * Create a HEX formatted string checksum hash of the data from the URL
+     *
+     * @param url           the {@link URL} to hash
+     * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
+     * @return the hash as a hex-formatted string
+     * @throws IOException if there is a problem reading from the URL
+     */
+    public static String hash(final URL url, final MessageDigest messageDigest) throws IOException {
+        return hash(url, messageDigest, null);
+    }
 
-          // Manual redirect following
-          if (code >= 300 && code < 400) {
-            String location = conn.getHeaderField("Location");
-            URL nextUrl = new URL(currentUrl, location);
-            if (!currentUrl.getAuthority().equals(nextUrl.getAuthority()) || !currentUrl.getProtocol().equals(nextUrl.getProtocol())) {
-              currentHeaders = null;
-            }
-            currentUrl = nextUrl;
-            logger.debug("Redirected to {}, currentHeaders stripped: {}", currentUrl, (currentHeaders == null));
-            retryChunk = true;
-            break; // Break retry loop to start new request with nextUrl
-          }
+    /**
+     * Create a HEX formatted string checksum hash of the data from the {@link FetchItem}
+     *
+     * @param item          the {@link FetchItem} to hash
+     * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
+     * @param extraHeaders  optional extra headers to send with the request
+     * @return the hash as a hex formatted string
+     * @throws IOException if there is a problem reading from the URL
+     */
+    public static String hash(final FetchItem item, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
+        long totalSize = (item.length != null && item.length >= 0) ? item.length : -1;
+        URL currentUrl = item.url;
+        Map<String, String> currentHeaders = extraHeaders;
 
-          if (code == 206) {
-            if (totalSize < 0) {
-              String contentRange = conn.getHeaderField("Content-Range");
-              if (contentRange != null && contentRange.contains("/")) {
-                try {
-                  totalSize = Long.parseLong(contentRange.substring(contentRange.lastIndexOf("/") + 1));
-                } catch (NumberFormatException e) {
-                  logger.warn("Could not parse Content-Range: {}", contentRange);
-                }
-              }
-            }
-            try (InputStream is = conn.getInputStream()) {
-              int bytesRead = updateDigestFromStream(is, messageDigest);
-              System.out.println("Read " + bytesRead + " bytes");
-              if (bytesRead < 0) {
-                throw new IOException("Stream closed unexpectedly for " + currentUrl);
-              }
-              offset += bytesRead;
-            }
-            retryChunk = false;
-            break; // Success, go to next chunk
-          } else if (code == 200) {
-            logger.info("Server returned 200 OK for range request, downloading full stream from {}", currentUrl);
-            try (InputStream is = new BufferedInputStream(conn.getInputStream())) {
-              updateDigestFromStream(is, messageDigest);
-            }
-            return formatMessageDigest(messageDigest);
-          } else {
-            throw new IOException("Unexpected response code " + code + " for " + currentUrl);
-          }
-        } catch (IOException e) {
-          logger.warn("Error fetching range {} from {} (attempt {}/{}): {}", range, currentUrl, attempt + 1, maxRetries, e.getMessage());
-          if (attempt < maxRetries - 1) {
-            try {
-              Thread.sleep(retrySleepMs);
-            } catch (InterruptedException ie) {
-              Thread.currentThread().interrupt();
-              throw new IOException("Interrupted during retry sleep", ie);
-            }
-          } else {
-            logger.info("Falling back to full stream for {} after failed range requests", currentUrl);
+        if (!currentUrl.getProtocol().startsWith("http")) {
             return hashFullStream(currentUrl, messageDigest, currentHeaders);
-          }
         }
-      }
-      if (retryChunk) {
-        continue;
-      }
-      if (totalSize > 0 && offset >= totalSize) {
-        break;
-      }
+
+        long chunkSize = Long.getLong(CHUNK_SIZE_PROP, DEFAULT_CHUNK_SIZE);
+        int maxRetries = Integer.getInteger(MAX_RETRIES_PROP, DEFAULT_MAX_RETRIES);
+        int retrySleepMs = Integer.getInteger(RETRY_SLEEP_MS_PROP, DEFAULT_RETRY_SLEEP_MS);
+
+        long offset = 0;
+        while (totalSize < 0 || offset < totalSize) {
+            long end = (totalSize > 0) ? Math.min(offset + chunkSize - 1, totalSize - 1) : offset + chunkSize - 1;
+            String range = "bytes=" + offset + "-" + end;
+
+            final URL finalUrl = currentUrl;
+            final Map<String, String> finalHeaders = currentHeaders;
+            final long finalTotalSize = totalSize;
+
+            try {
+                ChunkResult result = executeWithRetry(() -> {
+                    HttpURLConnection conn = openRangedConnection(finalUrl, range, finalHeaders);
+                    int code = conn.getResponseCode();
+
+                    // Manual redirect following
+                    if (code >= 300 && code < 400) {
+                        return ChunkResult.redirect(conn.getHeaderField("Location"));
+                    }
+
+                    if (code == 206) {
+                        return handlePartialContent(conn, messageDigest, finalTotalSize);
+                    }
+                    else if (code == 200) {
+                        logger.info("Server returned 200 OK for range request (probably range requests are not supported); downloading full stream from {}", finalUrl);
+                        try (InputStream is = conn.getInputStream()) {
+                            updateDigestFromStream(is, messageDigest);
+                        }
+                        return ChunkResult.fullStream(formatMessageDigest(messageDigest));
+                    }
+                    else {
+                        throw new IOException("Unexpected response code " + code + " for " + finalUrl);
+                    }
+                }, "Error fetching range " + range + " from " + currentUrl, maxRetries, retrySleepMs);
+
+                logger.debug("Processing chunk result for range {} from {}", range, currentUrl);
+
+                if (result.type == ChunkResultType.FULL_STREAM_SUCCESS) {
+                    logger.debug("Successfully processed full stream for range {} from {}", range, currentUrl);
+                    return result.hash;
+                }
+                else if (result.type == ChunkResultType.REDIRECT) {
+                    URL nextUrl = new URL(currentUrl, result.location);
+                    if (!currentUrl.getAuthority().equals(nextUrl.getAuthority()) || !currentUrl.getProtocol().equals(nextUrl.getProtocol())) {
+                        currentHeaders = null;
+                    }
+                    currentUrl = nextUrl;
+                    logger.debug("Redirected to {}, currentHeaders stripped: {}", currentUrl, (currentHeaders == null));
+                    // Skip offset update and retry the current chunk with new URL
+                }
+                else if (result.type == ChunkResultType.SUCCESS) {
+                    offset += result.bytesRead;
+                    if (totalSize < 0 && result.totalSize > 0) {
+                        totalSize = result.totalSize;
+                    }
+                    logger.debug("Successfully processed chunk for range {} from {}", range, currentUrl);
+                    logger.debug("Read {} of {}{}", offset, totalSize > 0 ? totalSize : "Unknown", totalSize > 0 ? " (" + (offset * 100L / totalSize) + "%)" : "");
+                }
+            }
+            catch (IOException e) {
+                logger.info("Falling back to full stream for {} after failed range requests", currentUrl);
+                return hashFullStream(currentUrl, messageDigest, currentHeaders);
+            }
+        }
+
+        return formatMessageDigest(messageDigest);
     }
 
-    return formatMessageDigest(messageDigest);
-  }
+    private static String hashFullStream(final URL url, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
+        URL currentUrl = url;
+        Map<String, String> currentHeaders = extraHeaders;
 
-  private static String hashFullStream(final URL url, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
-    URL currentUrl = url;
-    Map<String, String> currentHeaders = extraHeaders;
-
-    while (true) {
-      URLConnection conn = currentUrl.openConnection();
-      if (conn instanceof HttpURLConnection httpConn) {
-        httpConn.setInstanceFollowRedirects(false);
-        if (currentHeaders != null) {
-          for (Entry<String, String> entry : currentHeaders.entrySet()) {
-            httpConn.setRequestProperty(entry.getKey(), entry.getValue());
-          }
+        while (true) {
+            URLConnection conn = currentUrl.openConnection();
+            if (conn instanceof HttpURLConnection httpConn) {
+                httpConn.setInstanceFollowRedirects(false);
+                if (currentHeaders != null) {
+                    for (Entry<String, String> entry : currentHeaders.entrySet()) {
+                        httpConn.setRequestProperty(entry.getKey(), entry.getValue());
+                    }
+                }
+                int code = httpConn.getResponseCode();
+                if (code >= 300 && code < 400) {
+                    String location = httpConn.getHeaderField("Location");
+                    URL nextUrl = new URL(currentUrl, location);
+                    if (!currentUrl.getAuthority().equals(nextUrl.getAuthority()) || !currentUrl.getProtocol().equals(nextUrl.getProtocol())) {
+                        currentHeaders = null;
+                    }
+                    currentUrl = nextUrl;
+                    continue;
+                }
+                if (code != 200) {
+                    throw new IOException("Unexpected response code " + code + " for " + currentUrl);
+                }
+            }
+            try (final InputStream is = conn.getInputStream()) {
+                updateDigestFromStream(is, messageDigest);
+            }
+            break;
         }
-        int code = httpConn.getResponseCode();
-        if (code >= 300 && code < 400) {
-          String location = httpConn.getHeaderField("Location");
-          URL nextUrl = new URL(currentUrl, location);
-          if (!currentUrl.getAuthority().equals(nextUrl.getAuthority()) || !currentUrl.getProtocol().equals(nextUrl.getProtocol())) {
-            currentHeaders = null;
-          }
-          currentUrl = nextUrl;
-          continue;
-        }
-        if (code != 200) {
-          throw new IOException("Unexpected response code " + code + " for " + currentUrl);
-        }
-      }
-      try (final InputStream is = new BufferedInputStream(conn.getInputStream())) {
-        updateDigestFromStream(is, messageDigest);
-      }
-      break;
+        return formatMessageDigest(messageDigest);
     }
-    return formatMessageDigest(messageDigest);
-  }
 
-  /**
-   * Create a HEX formatted string checksum hash of the data from the URL
-   *
-   * @param url the {@link URL} to hash
-   * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
-   * @param extraHeaders optional extra headers to send with the request
-   * @return the hash as a hex formatted string
-   * @throws IOException if there is a problem reading from the URL
-   */
-  public static String hash(final URL url, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
-    return hash(new FetchItem(url, -1L, null), messageDigest, extraHeaders);
-  }
+    /**
+     * Create a HEX formatted string checksum hash of the data from the URL
+     *
+     * @param url           the {@link URL} to hash
+     * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
+     * @param extraHeaders  optional extra headers to send with the request
+     * @return the hash as a hex formatted string
+     * @throws IOException if there is a problem reading from the URL
+     */
+    public static String hash(final URL url, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
+        return hash(new FetchItem(url, -1L, null), messageDigest, extraHeaders);
+    }
 
-  private static void hashWithRangeRequests(final URL url, final MessageDigest messageDigest, final long totalSize, final Map<String, String> extraHeaders) throws IOException {
-    hash(new FetchItem(url, totalSize, null), messageDigest, extraHeaders);
-  }
-
-  private static int executeWithRetries(URL url, String range, MessageDigest messageDigest, int maxRetries, int retrySleepMs, final Map<String, String> extraHeaders) throws IOException {
-    for (int attempt = 0; attempt < maxRetries; attempt++) {
-      try {
-        HttpURLConnection conn = openRangedConnection(url, range, extraHeaders);
-        int code = conn.getResponseCode();
-        if (code != 206 && code != 200) {
-          throw new IOException("Unexpected response code " + code + " for range " + range);
+    private static ChunkResult handlePartialContent(HttpURLConnection conn, MessageDigest messageDigest, long currentTotalSize) throws IOException {
+        long totalSize = currentTotalSize;
+        if (totalSize < 0) {
+            String contentRange = conn.getHeaderField("Content-Range");
+            if (contentRange != null && contentRange.contains("/")) {
+                try {
+                    totalSize = Long.parseLong(contentRange.substring(contentRange.lastIndexOf("/") + 1));
+                }
+                catch (NumberFormatException e) {
+                    logger.warn("Could not parse Content-Range: {}", contentRange);
+                }
+            }
         }
         try (InputStream is = conn.getInputStream()) {
-          return updateDigestFromStream(is, messageDigest);
+            int bytesRead = updateDigestFromStream(is, messageDigest);
+            if (bytesRead < 0) {
+                throw new IOException("Stream closed unexpectedly for " + conn.getURL());
+            }
+            return ChunkResult.success(bytesRead, totalSize);
         }
-      } catch (IOException e) {
-        logger.warn("Error fetching range {} (attempt {}/{}): {}", range, attempt + 1, maxRetries, e.getMessage());
-        if (attempt < maxRetries - 1) {
-          try {
-            Thread.sleep(retrySleepMs);
-          } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-            throw new IOException("Interrupted during retry sleep", ie);
-          }
-        } else {
-          throw e;
+    }
+
+    private static ChunkResult executeWithRetry(RetryableOperation<ChunkResult> operation, String description, int maxRetries, int retrySleepMs) throws IOException {
+        for (int attempt = 0; attempt < maxRetries; attempt++) {
+            try {
+                ChunkResult result = operation.execute();
+                if (result.type == ChunkResultType.REDIRECT) {
+                    return result; // Break the retry loop for redirects
+                }
+                return result;
+            }
+            catch (IOException e) {
+                logger.warn("{} (attempt {}/{}): {}", description, attempt + 1, maxRetries, e.getMessage());
+                if (attempt < maxRetries - 1) {
+                    try {
+                        Thread.sleep(retrySleepMs);
+                    }
+                    catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Interrupted during retry sleep", ie);
+                    }
+                }
+                else {
+                    throw e;
+                }
+            }
         }
-      }
+        throw new IOException("Max retries exceeded");
     }
-    return -1;
-  }
 
-  /**
-   * Opens a HttpURLConnection for the given range.
-   */
-  private static HttpURLConnection openRangedConnection(URL url, String range, final Map<String, String> extraHeaders) throws IOException {
-    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    if (extraHeaders != null) {
-      for (Entry<String, String> entry : extraHeaders.entrySet()) {
-        conn.setRequestProperty(entry.getKey(), entry.getValue());
-      }
+    @FunctionalInterface
+    private interface RetryableOperation<T> {
+        T execute() throws IOException;
     }
-    conn.setInstanceFollowRedirects(false);
-    if (range != null) {
-      conn.setRequestProperty("Range", range);
-    }
-    return conn;
-  }
 
-  /**
-   * Reads from the InputStream and updates the MessageDigest. Returns the number of bytes read.
-   */
-  private static int updateDigestFromStream(InputStream is, MessageDigest messageDigest) throws IOException {
-    byte[] buffer = new byte[CHUNK_SIZE];
-    int totalRead = 0;
-    int read = is.read(buffer);
-    while (read != -1) {
-      messageDigest.update(buffer, 0, read);
-      totalRead += read;
-      read = is.read(buffer);
+    private enum ChunkResultType {
+        SUCCESS, REDIRECT, FULL_STREAM_SUCCESS
     }
-    return totalRead;
-  }
-  
-  /**
-   * Update the Manifests with the file's hash
-   * 
-   * @param path the {@link Path} (file) to hash
-   * @param manifestToMessageDigestMap the map between {@link Manifest} and {@link MessageDigest}
-   * @throws IOException if there is a problem reading the file
-   */
-  public static void hash(final Path path, final Map<Manifest, MessageDigest> manifestToMessageDigestMap) throws IOException {
-    updateMessageDigests(path, manifestToMessageDigestMap.values());
-    addMessageDigestHashToManifest(path, manifestToMessageDigestMap);
-  }
-  
-  static void updateMessageDigests(final Path path, final Collection<MessageDigest> messageDigests) throws IOException{
-    try(final InputStream is = new BufferedInputStream(Files.newInputStream(path, StandardOpenOption.READ))){
-      final byte[] buffer = new byte[CHUNK_SIZE];
-      int read = is.read(buffer);
-      
-      while(read != -1) {
-        for(final MessageDigest messageDigest : messageDigests){
-          messageDigest.update(buffer, 0, read);
+
+    /**
+     * Represents the result of a chunk operation when processing data for hashing. A chunk operation can have various results, such as a successful read, a redirection to another location, or
+     * successful processing of a complete stream.
+     */
+    private static class ChunkResult {
+        final ChunkResultType type;
+        final int bytesRead;
+        final long totalSize;
+        final String location;
+        final String hash;
+
+        private ChunkResult(ChunkResultType type, int bytesRead, long totalSize, String location, String hash) {
+            this.type = type;
+            this.bytesRead = bytesRead;
+            this.totalSize = totalSize;
+            this.location = location;
+            this.hash = hash;
         }
-        read = is.read(buffer);
-      }
-    }
-  }
-  
-  private static void addMessageDigestHashToManifest(final Path path, final Map<Manifest, MessageDigest> manifestToMessageDigestMap){
-    for(final Entry<Manifest, MessageDigest> entry : manifestToMessageDigestMap.entrySet()){
-      final String hash = formatMessageDigest(entry.getValue());
-      logger.debug(messages.getString("adding_checksum"), path, hash);
-      entry.getKey().getFileToChecksumMap().put(path, hash);
-    }
-  }
-  
-  //Convert the byte to hex format
-  private static String formatMessageDigest(final MessageDigest messageDigest){
-    try(final Formatter formatter = new Formatter()){
-      for (final byte b : messageDigest.digest()) {
-        formatter.format("%02x", b);
-      }
-      
-      return formatter.toString();
-    }
-  }
-  
-  /**
-   * create a mapping between {@link Manifest} and {@link MessageDigest} for each each supplied {@link SupportedAlgorithm} 
-   * 
-   * @param algorithms the {@link SupportedAlgorithm} that you which to map to {@link MessageDigest} 
-   * @return mapping between {@link Manifest} and {@link MessageDigest}
-   * @throws NoSuchAlgorithmException if {@link MessageDigest} doesn't support the algorithm
-   */
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-  public static Map<Manifest, MessageDigest> createManifestToMessageDigestMap(final Collection<SupportedAlgorithm> algorithms) throws NoSuchAlgorithmException{
-    final Map<Manifest, MessageDigest> map = new HashMap<>();
 
-    for(final SupportedAlgorithm algorithm : algorithms){
-      final MessageDigest messageDigest = MessageDigest.getInstance(algorithm.getMessageDigestName());
-      final Manifest manifest = new Manifest(algorithm);
-      map.put(manifest, messageDigest);
+        static ChunkResult success(int bytesRead, long totalSize) {
+            return new ChunkResult(ChunkResultType.SUCCESS, bytesRead, totalSize, null, null);
+        }
+
+        static ChunkResult redirect(String location) {
+            return new ChunkResult(ChunkResultType.REDIRECT, 0, -1, location, null);
+        }
+
+        static ChunkResult fullStream(String hash) {
+            return new ChunkResult(ChunkResultType.FULL_STREAM_SUCCESS, 0, -1, null, hash);
+        }
     }
-    
-    return map;
-  }
+
+    /**
+     * Opens a HttpURLConnection for the given range.
+     */
+    private static HttpURLConnection openRangedConnection(URL url, String range, final Map<String, String> extraHeaders) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        if (extraHeaders != null) {
+            for (Entry<String, String> entry : extraHeaders.entrySet()) {
+                conn.setRequestProperty(entry.getKey(), entry.getValue());
+            }
+        }
+        conn.setInstanceFollowRedirects(false);
+        if (range != null) {
+            conn.setRequestProperty("Range", range);
+        }
+        return conn;
+    }
+
+    /**
+     * Reads from the InputStream and updates the MessageDigest. Returns the number of bytes read.
+     */
+    private static int updateDigestFromStream(InputStream is, MessageDigest messageDigest) throws IOException {
+        byte[] buffer = new byte[CHUNK_SIZE];
+        int totalRead = 0;
+        int read = is.read(buffer);
+        while (read != -1) {
+            messageDigest.update(buffer, 0, read);
+            totalRead += read;
+            read = is.read(buffer);
+        }
+        return totalRead;
+    }
+
+    /**
+     * Update the Manifests with the file's hash
+     *
+     * @param path                       the {@link Path} (file) to hash
+     * @param manifestToMessageDigestMap the map between {@link Manifest} and {@link MessageDigest}
+     * @throws IOException if there is a problem reading the file
+     */
+    public static void hash(final Path path, final Map<Manifest, MessageDigest> manifestToMessageDigestMap) throws IOException {
+        updateMessageDigests(path, manifestToMessageDigestMap.values());
+        addMessageDigestHashToManifest(path, manifestToMessageDigestMap);
+    }
+
+    static void updateMessageDigests(final Path path, final Collection<MessageDigest> messageDigests) throws IOException {
+        try (final InputStream is = new BufferedInputStream(Files.newInputStream(path, StandardOpenOption.READ))) {
+            final byte[] buffer = new byte[CHUNK_SIZE];
+            int read = is.read(buffer);
+
+            while (read != -1) {
+                for (final MessageDigest messageDigest : messageDigests) {
+                    messageDigest.update(buffer, 0, read);
+                }
+                read = is.read(buffer);
+            }
+        }
+    }
+
+    private static void addMessageDigestHashToManifest(final Path path, final Map<Manifest, MessageDigest> manifestToMessageDigestMap) {
+        for (final Entry<Manifest, MessageDigest> entry : manifestToMessageDigestMap.entrySet()) {
+            final String hash = formatMessageDigest(entry.getValue());
+            logger.debug(messages.getString("adding_checksum"), path, hash);
+            entry.getKey().getFileToChecksumMap().put(path, hash);
+        }
+    }
+
+    //Convert the byte to hex format
+    private static String formatMessageDigest(final MessageDigest messageDigest) {
+        try (final Formatter formatter = new Formatter()) {
+            for (final byte b : messageDigest.digest()) {
+                formatter.format("%02x", b);
+            }
+
+            return formatter.toString();
+        }
+    }
+
+    /**
+     * create a mapping between {@link Manifest} and {@link MessageDigest} for each each supplied {@link SupportedAlgorithm}
+     *
+     * @param algorithms the {@link SupportedAlgorithm} that you which to map to {@link MessageDigest}
+     * @return mapping between {@link Manifest} and {@link MessageDigest}
+     * @throws NoSuchAlgorithmException if {@link MessageDigest} doesn't support the algorithm
+     */
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    public static Map<Manifest, MessageDigest> createManifestToMessageDigestMap(final Collection<SupportedAlgorithm> algorithms) throws NoSuchAlgorithmException {
+        final Map<Manifest, MessageDigest> map = new HashMap<>();
+
+        for (final SupportedAlgorithm algorithm : algorithms) {
+            final MessageDigest messageDigest = MessageDigest.getInstance(algorithm.getMessageDigestName());
+            final Manifest manifest = new Manifest(algorithm);
+            map.put(manifest, messageDigest);
+        }
+
+        return map;
+    }
 }

--- a/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
+++ b/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
@@ -122,47 +122,67 @@ public final class Hasher {
     while (offset < totalSize) {
       long end = Math.min(offset + chunkSize - 1, totalSize - 1);
       String range = "bytes=" + offset + "-" + end;
-      
-      boolean success = false;
-      for (int attempt = 0; attempt < maxRetries; attempt++) {
-        try {
-          HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-          conn.setRequestProperty("Range", range);
-          int code = conn.getResponseCode();
-          
-          if (code != 206 && code != 200) {
-             throw new IOException("Unexpected response code " + code + " for range " + range);
-          }
-          
-          try (InputStream is = conn.getInputStream()) {
-            byte[] buffer = new byte[CHUNK_SIZE];
-            int read = is.read(buffer);
-            while (read != -1) {
-              messageDigest.update(buffer, 0, read);
-              offset += read;
-              read = is.read(buffer);
-            }
-          }
-          success = true;
-          break;
-        } catch (IOException e) {
-          logger.warn("Error fetching range {} (attempt {}/{}): {}", range, attempt + 1, maxRetries, e.getMessage());
-          if (attempt < maxRetries - 1) {
-            try {
-              Thread.sleep(retrySleepMs);
-            } catch (InterruptedException ie) {
-              Thread.currentThread().interrupt();
-              throw new IOException("Interrupted during retry sleep", ie);
-            }
-          } else {
-            throw e;
-          }
-        }
-      }
-      if (!success) {
+      int bytesRead = executeWithRetries(url, range, messageDigest, maxRetries, retrySleepMs);
+      if (bytesRead < 0) {
         throw new IOException("Failed to fetch range " + range + " after " + maxRetries + " attempts");
       }
+      offset += (end - offset + 1); // Move to next chunk
     }
+  }
+
+  /**
+   * Executes the ranged request with retry logic. Returns the number of bytes read, or -1 if all retries failed.
+   */
+  private static int executeWithRetries(URL url, String range, MessageDigest messageDigest, int maxRetries, int retrySleepMs) throws IOException {
+    for (int attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        HttpURLConnection conn = openRangedConnection(url, range);
+        int code = conn.getResponseCode();
+        if (code != 206 && code != 200) {
+          throw new IOException("Unexpected response code " + code + " for range " + range);
+        }
+        try (InputStream is = conn.getInputStream()) {
+          return updateDigestFromStream(is, messageDigest);
+        }
+      } catch (IOException e) {
+        logger.warn("Error fetching range {} (attempt {}/{}): {}", range, attempt + 1, maxRetries, e.getMessage());
+        if (attempt < maxRetries - 1) {
+          try {
+            Thread.sleep(retrySleepMs);
+          } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted during retry sleep", ie);
+          }
+        } else {
+          throw e;
+        }
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Opens a HttpURLConnection for the given range.
+   */
+  private static HttpURLConnection openRangedConnection(URL url, String range) throws IOException {
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setRequestProperty("Range", range);
+    return conn;
+  }
+
+  /**
+   * Reads from the InputStream and updates the MessageDigest. Returns the number of bytes read.
+   */
+  private static int updateDigestFromStream(InputStream is, MessageDigest messageDigest) throws IOException {
+    byte[] buffer = new byte[CHUNK_SIZE];
+    int totalRead = 0;
+    int read = is.read(buffer);
+    while (read != -1) {
+      messageDigest.update(buffer, 0, read);
+      totalRead += read;
+      read = is.read(buffer);
+    }
+    return totalRead;
   }
   
   /**

--- a/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
+++ b/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Map.Entry;
 
+import nl.knaw.dans.bagit.domain.FetchItem;
 import nl.knaw.dans.bagit.domain.Manifest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +52,7 @@ public final class Hasher {
   private static final String MAX_RETRIES_PROP = "nl.knaw.dans.bagit.hash.maxRetries";
   private static final String RETRY_SLEEP_MS_PROP = "nl.knaw.dans.bagit.hash.retrySleepMs";
 
-  private static final long DEFAULT_CHUNK_SIZE = 1024L * 1024L; // 1 MiB
+  private static final long DEFAULT_CHUNK_SIZE = 500 * 1024L * 1024L; // 1 MiB
   private static final int DEFAULT_MAX_RETRIES = 5;
   private static final int DEFAULT_RETRY_SLEEP_MS = 5000;
   
@@ -86,6 +87,143 @@ public final class Hasher {
   }
 
   /**
+   * Create a HEX formatted string checksum hash of the data from the {@link FetchItem}
+   *
+   * @param item the {@link FetchItem} to hash
+   * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
+   * @param extraHeaders optional extra headers to send with the request
+   * @return the hash as a hex formatted string
+   * @throws IOException if there is a problem reading from the URL
+   */
+  public static String hash(final FetchItem item, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
+    long totalSize = (item.length != null && item.length >= 0) ? item.length : -1;
+    URL currentUrl = item.url;
+    Map<String, String> currentHeaders = extraHeaders;
+
+    if (!currentUrl.getProtocol().startsWith("http")) {
+      return hashFullStream(currentUrl, messageDigest, currentHeaders);
+    }
+
+    long chunkSize = Long.getLong(CHUNK_SIZE_PROP, DEFAULT_CHUNK_SIZE);
+    int maxRetries = Integer.getInteger(MAX_RETRIES_PROP, DEFAULT_MAX_RETRIES);
+    int retrySleepMs = Integer.getInteger(RETRY_SLEEP_MS_PROP, DEFAULT_RETRY_SLEEP_MS);
+
+    long offset = 0;
+    while (totalSize < 0 || offset < totalSize) {
+      long end = (totalSize > 0) ? Math.min(offset + chunkSize - 1, totalSize - 1) : offset + chunkSize - 1;
+      String range = "bytes=" + offset + "-" + end;
+
+      boolean retryChunk = false;
+      for (int attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          HttpURLConnection conn = openRangedConnection(currentUrl, range, currentHeaders);
+          int code = conn.getResponseCode();
+
+          // Manual redirect following
+          if (code >= 300 && code < 400) {
+            String location = conn.getHeaderField("Location");
+            URL nextUrl = new URL(currentUrl, location);
+            if (!currentUrl.getAuthority().equals(nextUrl.getAuthority()) || !currentUrl.getProtocol().equals(nextUrl.getProtocol())) {
+              currentHeaders = null;
+            }
+            currentUrl = nextUrl;
+            logger.debug("Redirected to {}, currentHeaders stripped: {}", currentUrl, (currentHeaders == null));
+            retryChunk = true;
+            break; // Break retry loop to start new request with nextUrl
+          }
+
+          if (code == 206) {
+            if (totalSize < 0) {
+              String contentRange = conn.getHeaderField("Content-Range");
+              if (contentRange != null && contentRange.contains("/")) {
+                try {
+                  totalSize = Long.parseLong(contentRange.substring(contentRange.lastIndexOf("/") + 1));
+                } catch (NumberFormatException e) {
+                  logger.warn("Could not parse Content-Range: {}", contentRange);
+                }
+              }
+            }
+            try (InputStream is = conn.getInputStream()) {
+              int bytesRead = updateDigestFromStream(is, messageDigest);
+              System.out.println("Read " + bytesRead + " bytes");
+              if (bytesRead < 0) {
+                throw new IOException("Stream closed unexpectedly for " + currentUrl);
+              }
+              offset += bytesRead;
+            }
+            retryChunk = false;
+            break; // Success, go to next chunk
+          } else if (code == 200) {
+            logger.info("Server returned 200 OK for range request, downloading full stream from {}", currentUrl);
+            try (InputStream is = new BufferedInputStream(conn.getInputStream())) {
+              updateDigestFromStream(is, messageDigest);
+            }
+            return formatMessageDigest(messageDigest);
+          } else {
+            throw new IOException("Unexpected response code " + code + " for " + currentUrl);
+          }
+        } catch (IOException e) {
+          logger.warn("Error fetching range {} from {} (attempt {}/{}): {}", range, currentUrl, attempt + 1, maxRetries, e.getMessage());
+          if (attempt < maxRetries - 1) {
+            try {
+              Thread.sleep(retrySleepMs);
+            } catch (InterruptedException ie) {
+              Thread.currentThread().interrupt();
+              throw new IOException("Interrupted during retry sleep", ie);
+            }
+          } else {
+            logger.info("Falling back to full stream for {} after failed range requests", currentUrl);
+            return hashFullStream(currentUrl, messageDigest, currentHeaders);
+          }
+        }
+      }
+      if (retryChunk) {
+        continue;
+      }
+      if (totalSize > 0 && offset >= totalSize) {
+        break;
+      }
+    }
+
+    return formatMessageDigest(messageDigest);
+  }
+
+  private static String hashFullStream(final URL url, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
+    URL currentUrl = url;
+    Map<String, String> currentHeaders = extraHeaders;
+
+    while (true) {
+      URLConnection conn = currentUrl.openConnection();
+      if (conn instanceof HttpURLConnection httpConn) {
+        httpConn.setInstanceFollowRedirects(false);
+        if (currentHeaders != null) {
+          for (Entry<String, String> entry : currentHeaders.entrySet()) {
+            httpConn.setRequestProperty(entry.getKey(), entry.getValue());
+          }
+        }
+        int code = httpConn.getResponseCode();
+        if (code >= 300 && code < 400) {
+          String location = httpConn.getHeaderField("Location");
+          URL nextUrl = new URL(currentUrl, location);
+          if (!currentUrl.getAuthority().equals(nextUrl.getAuthority()) || !currentUrl.getProtocol().equals(nextUrl.getProtocol())) {
+            currentHeaders = null;
+          }
+          currentUrl = nextUrl;
+          continue;
+        }
+        if (code != 200) {
+          throw new IOException("Unexpected response code " + code + " for " + currentUrl);
+        }
+      }
+      try (final InputStream is = new BufferedInputStream(conn.getInputStream())) {
+        updateDigestFromStream(is, messageDigest);
+      }
+      break;
+    }
+    return formatMessageDigest(messageDigest);
+  }
+
+  /**
    * Create a HEX formatted string checksum hash of the data from the URL
    *
    * @param url the {@link URL} to hash
@@ -95,78 +233,13 @@ public final class Hasher {
    * @throws IOException if there is a problem reading from the URL
    */
   public static String hash(final URL url, final MessageDigest messageDigest, final Map<String, String> extraHeaders) throws IOException {
-    long totalSize = -1;
-    boolean rangeSupported = false;
-    URLConnection connection = url.openConnection();
-
-    if (connection instanceof HttpURLConnection httpConnection) {
-      httpConnection.setRequestMethod("HEAD");
-      httpConnection.setInstanceFollowRedirects(true);
-      if (extraHeaders != null) {
-        for (Entry<String, String> entry : extraHeaders.entrySet()) {
-          httpConnection.setRequestProperty(entry.getKey(), entry.getValue());
-        }
-      }
-
-      int responseCode = httpConnection.getResponseCode();
-      if (responseCode >= 300 && responseCode < 400) {
-        String newUrl = httpConnection.getHeaderField("Location");
-        return hash(new URL(newUrl), messageDigest, extraHeaders);
-      }
-
-      totalSize = httpConnection.getContentLengthLong();
-      String acceptRanges = httpConnection.getHeaderField("Accept-Ranges");
-      rangeSupported = "bytes".equalsIgnoreCase(acceptRanges);
-    }
-
-    if (rangeSupported && totalSize > 0) {
-      logger.info("Range requests supported for {}, downloading in chunks", url);
-      hashWithRangeRequests(url, messageDigest, totalSize, extraHeaders);
-    } else {
-      logger.info("Range requests NOT supported or size unknown for {}, downloading full stream", url);
-      URLConnection conn = url.openConnection();
-      if (conn instanceof HttpURLConnection httpConn) {
-        httpConn.setInstanceFollowRedirects(true);
-        if (extraHeaders != null) {
-          for (Entry<String, String> entry : extraHeaders.entrySet()) {
-            httpConn.setRequestProperty(entry.getKey(), entry.getValue());
-          }
-        }
-      }
-      try (final InputStream is = new BufferedInputStream(conn.getInputStream())) {
-        final byte[] buffer = new byte[CHUNK_SIZE];
-        int read = is.read(buffer);
-
-        while (read != -1) {
-          messageDigest.update(buffer, 0, read);
-          read = is.read(buffer);
-        }
-      }
-    }
-
-    return formatMessageDigest(messageDigest);
+    return hash(new FetchItem(url, -1L, null), messageDigest, extraHeaders);
   }
 
   private static void hashWithRangeRequests(final URL url, final MessageDigest messageDigest, final long totalSize, final Map<String, String> extraHeaders) throws IOException {
-    long chunkSize = Long.getLong(CHUNK_SIZE_PROP, DEFAULT_CHUNK_SIZE);
-    int maxRetries = Integer.getInteger(MAX_RETRIES_PROP, DEFAULT_MAX_RETRIES);
-    int retrySleepMs = Integer.getInteger(RETRY_SLEEP_MS_PROP, DEFAULT_RETRY_SLEEP_MS);
-
-    long offset = 0;
-    while (offset < totalSize) {
-      long end = Math.min(offset + chunkSize - 1, totalSize - 1);
-      String range = "bytes=" + offset + "-" + end;
-      int bytesRead = executeWithRetries(url, range, messageDigest, maxRetries, retrySleepMs, extraHeaders);
-      if (bytesRead < 0) {
-        throw new IOException("Failed to fetch range " + range + " after " + maxRetries + " attempts");
-      }
-      offset += (end - offset + 1); // Move to next chunk
-    }
+    hash(new FetchItem(url, totalSize, null), messageDigest, extraHeaders);
   }
 
-  /**
-   * Executes the ranged request with retry logic. Returns the number of bytes read, or -1 if all retries failed.
-   */
   private static int executeWithRetries(URL url, String range, MessageDigest messageDigest, int maxRetries, int retrySleepMs, final Map<String, String> extraHeaders) throws IOException {
     for (int attempt = 0; attempt < maxRetries; attempt++) {
       try {
@@ -200,13 +273,15 @@ public final class Hasher {
    */
   private static HttpURLConnection openRangedConnection(URL url, String range, final Map<String, String> extraHeaders) throws IOException {
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-    conn.setInstanceFollowRedirects(true);
     if (extraHeaders != null) {
       for (Entry<String, String> entry : extraHeaders.entrySet()) {
         conn.setRequestProperty(entry.getKey(), entry.getValue());
       }
     }
-    conn.setRequestProperty("Range", range);
+    conn.setInstanceFollowRedirects(false);
+    if (range != null) {
+      conn.setRequestProperty("Range", range);
+    }
     return conn;
   }
 

--- a/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
+++ b/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -83,12 +84,10 @@ public final class Hasher {
   public static String hash(final URL url, final MessageDigest messageDigest) throws IOException {
     long totalSize = -1;
     boolean rangeSupported = false;
-    java.net.URLConnection connection = url.openConnection();
+    URLConnection connection = url.openConnection();
 
-    if (connection instanceof HttpURLConnection) {
-      HttpURLConnection httpConnection = (HttpURLConnection) connection;
+    if (connection instanceof HttpURLConnection httpConnection) {
       httpConnection.setRequestMethod("HEAD");
-      int responseCode = httpConnection.getResponseCode();
 
       totalSize = httpConnection.getContentLengthLong();
       String acceptRanges = httpConnection.getHeaderField("Accept-Ranges");

--- a/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
+++ b/src/main/java/nl/knaw/dans/bagit/hash/Hasher.java
@@ -18,6 +18,7 @@ package nl.knaw.dans.bagit.hash;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -59,6 +60,28 @@ public final class Hasher {
   public static String hash(final Path path, final MessageDigest messageDigest) throws IOException {
     updateMessageDigests(path, Arrays.asList(messageDigest));
     
+    return formatMessageDigest(messageDigest);
+  }
+
+  /**
+   * Create a HEX formatted string checksum hash of the data from the URL
+   *
+   * @param url the {@link URL} to hash
+   * @param messageDigest the {@link MessageDigest} object representing the hashing algorithm
+   * @return the hash as a hex formatted string
+   * @throws IOException if there is a problem reading from the URL
+   */
+  public static String hash(final URL url, final MessageDigest messageDigest) throws IOException {
+    try (final InputStream is = new BufferedInputStream(url.openStream())) {
+      final byte[] buffer = new byte[CHUNK_SIZE];
+      int read = is.read(buffer);
+
+      while (read != -1) {
+        messageDigest.update(buffer, 0, read);
+        read = is.read(buffer);
+      }
+    }
+
     return formatMessageDigest(messageDigest);
   }
   

--- a/src/main/java/nl/knaw/dans/bagit/reader/TagFileReader.java
+++ b/src/main/java/nl/knaw/dans/bagit/reader/TagFileReader.java
@@ -52,7 +52,7 @@ public interface TagFileReader {
       throw new InvalidBagitFileFormatException(MessageFormatter.format(formattedMessage, path).getMessage());
     }
     
-    if(path.contains("~/")){
+    if(path.contains("~/") || path.startsWith("~")){
       final String formattedMessage = messages.getString("malicious_path_error");
       throw new MaliciousPathException(MessageFormatter.format(formattedMessage, path).getMessage());
     }

--- a/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
@@ -163,16 +163,16 @@ public final class BagVerifier implements AutoCloseable{
     final boolean holey = allowHoley || !bag.getItemsToFetch().isEmpty();
     isComplete(bag, ignoreHiddenFiles, holey);
 
-    final Map<Path, URL> fetchUrls = new HashMap<>();
+    final Map<Path, FetchItem> fetchItems = new HashMap<>();
     if (holey) {
       for (final FetchItem item : bag.getItemsToFetch()) {
-        fetchUrls.put(item.path, item.url);
+        fetchItems.put(item.path, item);
       }
     }
 
     logger.debug(messages.getString("checking_payload_checksums"));
     for(final Manifest payloadManifest : bag.getPayLoadManifests()){
-      checkHashes(payloadManifest, fetchUrls, holey, extraHeaders);
+      checkHashes(payloadManifest, fetchItems, holey, extraHeaders);
     }
 
     logger.debug(messages.getString("checking_tag_file_checksums"));
@@ -189,18 +189,18 @@ public final class BagVerifier implements AutoCloseable{
     checkHashes(manifest, null, false);
   }
 
-  void checkHashes(final Manifest manifest, final Map<Path, URL> fetchUrls, final boolean holey) throws CorruptChecksumException, InterruptedException, VerificationException{
-    checkHashes(manifest, fetchUrls, holey, null);
+  void checkHashes(final Manifest manifest, final Map<Path, FetchItem> fetchItems, final boolean holey) throws CorruptChecksumException, InterruptedException, VerificationException{
+    checkHashes(manifest, fetchItems, holey, null);
   }
 
-  void checkHashes(final Manifest manifest, final Map<Path, URL> fetchUrls, final boolean holey, final Map<String, String> extraHeaders) throws CorruptChecksumException, InterruptedException, VerificationException{
+  void checkHashes(final Manifest manifest, final Map<Path, FetchItem> fetchItems, final boolean holey, final Map<String, String> extraHeaders) throws CorruptChecksumException, InterruptedException, VerificationException{
     final CountDownLatch latch = new CountDownLatch( manifest.getFileToChecksumMap().size());
 
     //TODO maybe return all of these at some point...
     final Collection<Exception> exceptions = Collections.synchronizedCollection(new ArrayList<>());
 
     for(final Entry<Path, String> entry : manifest.getFileToChecksumMap().entrySet()){
-      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions, fetchUrls, holey, extraHeaders));
+      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions, fetchItems, holey, extraHeaders));
     }
 
     latch.await();

--- a/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
@@ -185,14 +185,14 @@ public final class BagVerifier implements AutoCloseable{
     checkHashes(manifest, null, false);
   }
 
-  void checkHashes(final Manifest manifest, final Map<Path, URL> fetchUrls, final boolean allowHoley) throws CorruptChecksumException, InterruptedException, VerificationException{
+  void checkHashes(final Manifest manifest, final Map<Path, URL> fetchUrls, final boolean holey) throws CorruptChecksumException, InterruptedException, VerificationException{
     final CountDownLatch latch = new CountDownLatch( manifest.getFileToChecksumMap().size());
 
     //TODO maybe return all of these at some point...
     final Collection<Exception> exceptions = Collections.synchronizedCollection(new ArrayList<>());
 
     for(final Entry<Path, String> entry : manifest.getFileToChecksumMap().entrySet()){
-      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions, fetchUrls, allowHoley));
+      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions, fetchUrls, holey));
     }
 
     latch.await();

--- a/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
@@ -16,10 +16,13 @@
 package nl.knaw.dans.bagit.verify;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.concurrent.CountDownLatch;
@@ -27,6 +30,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import nl.knaw.dans.bagit.domain.Bag;
+import nl.knaw.dans.bagit.domain.FetchItem;
 import nl.knaw.dans.bagit.domain.Manifest;
 import nl.knaw.dans.bagit.exceptions.CorruptChecksumException;
 import nl.knaw.dans.bagit.exceptions.FileNotInManifestException;
@@ -147,43 +151,59 @@ public final class BagVerifier implements AutoCloseable{
    * @throws InvalidBagitFileFormatException if the manifest is not formatted properly
    */
   public void isValid(final Bag bag, final boolean ignoreHiddenFiles) throws IOException, FileNotInManifestException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, CorruptChecksumException, VerificationException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
+    isValid(bag, ignoreHiddenFiles, false);
+  }
+
+  public void isValid(final Bag bag, final boolean ignoreHiddenFiles, final boolean isHoley) throws IOException, FileNotInManifestException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, CorruptChecksumException, VerificationException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
     logger.info(messages.getString("checking_bag_is_valid"), bag.getRootDir());
-    isComplete(bag, ignoreHiddenFiles);
-    
+    isComplete(bag, ignoreHiddenFiles, isHoley);
+
+    final Map<Path, URL> fetchUrls = new HashMap<>();
+    if (isHoley) {
+      for (final FetchItem item : bag.getItemsToFetch()) {
+        fetchUrls.put(item.path, item.url);
+      }
+    }
+
     logger.debug(messages.getString("checking_payload_checksums"));
     for(final Manifest payloadManifest : bag.getPayLoadManifests()){
-      checkHashes(payloadManifest);
+      checkHashes(payloadManifest, fetchUrls, isHoley);
     }
-    
+
     logger.debug(messages.getString("checking_tag_file_checksums"));
     for(final Manifest tagManifest : bag.getTagManifests()){
-      checkHashes(tagManifest);
+      checkHashes(tagManifest, null, false);
     }
   }
-  
+
   /*
    * Check the supplied checksum hashes against the generated checksum hashes
    */
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   void checkHashes(final Manifest manifest) throws CorruptChecksumException, InterruptedException, VerificationException{
+    checkHashes(manifest, null, false);
+  }
+
+  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+  void checkHashes(final Manifest manifest, final Map<Path, URL> fetchUrls, final boolean isHoley) throws CorruptChecksumException, InterruptedException, VerificationException{
     final CountDownLatch latch = new CountDownLatch( manifest.getFileToChecksumMap().size());
-    
+
     //TODO maybe return all of these at some point...
     final Collection<Exception> exceptions = Collections.synchronizedCollection(new ArrayList<>());
-    
+
     for(final Entry<Path, String> entry : manifest.getFileToChecksumMap().entrySet()){
-      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions));
+      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions, fetchUrls, isHoley));
     }
-    
+
     latch.await();
-    
+
     if(!exceptions.isEmpty()){
       final Exception e = exceptions.iterator().next();
       if(e instanceof CorruptChecksumException){
         logger.debug(messages.getString("checksums_not_matching_error"), exceptions.size());
         throw (CorruptChecksumException)e;
       }
-      
+
       throw new VerificationException(e);
     }
   }
@@ -215,17 +235,25 @@ public final class BagVerifier implements AutoCloseable{
   public void isComplete(final Bag bag, final boolean ignoreHiddenFiles) throws 
     IOException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, 
     FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
+    isComplete(bag, ignoreHiddenFiles, false);
+  }
+
+  public void isComplete(final Bag bag, final boolean ignoreHiddenFiles, final boolean isHoley) throws
+    IOException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException,
+    FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
     logger.info(messages.getString("checking_bag_is_complete"), bag.getRootDir());
-    
-    MandatoryVerifier.checkFetchItemsExist(bag.getItemsToFetch(), bag.getRootDir());
-    
+
+    if (!isHoley) {
+      MandatoryVerifier.checkFetchItemsExist(bag.getItemsToFetch(), bag.getRootDir());
+    }
+
     MandatoryVerifier.checkBagitFileExists(bag.getRootDir(), bag.getVersion());
-    
+
     MandatoryVerifier.checkPayloadDirectoryExists(bag);
-    
+
     MandatoryVerifier.checkIfAtLeastOnePayloadManifestsExist(bag.getRootDir(), bag.getVersion());
-    
-    manifestVerifier.verifyManifests(bag, ignoreHiddenFiles);
+
+    manifestVerifier.verifyManifests(bag, ignoreHiddenFiles, isHoley);
   }
   
   public ExecutorService getExecutor() {

--- a/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
@@ -154,12 +154,13 @@ public final class BagVerifier implements AutoCloseable{
     isValid(bag, ignoreHiddenFiles, false);
   }
 
-  public void isValid(final Bag bag, final boolean ignoreHiddenFiles, final boolean isHoley) throws IOException, FileNotInManifestException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, CorruptChecksumException, VerificationException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
+  public void isValid(final Bag bag, final boolean ignoreHiddenFiles, final boolean allowHoley) throws IOException, FileNotInManifestException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, CorruptChecksumException, VerificationException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
     logger.info(messages.getString("checking_bag_is_valid"), bag.getRootDir());
-    isComplete(bag, ignoreHiddenFiles, isHoley);
+    final boolean holey = allowHoley || !bag.getItemsToFetch().isEmpty();
+    isComplete(bag, ignoreHiddenFiles, holey);
 
     final Map<Path, URL> fetchUrls = new HashMap<>();
-    if (isHoley) {
+    if (holey) {
       for (final FetchItem item : bag.getItemsToFetch()) {
         fetchUrls.put(item.path, item.url);
       }
@@ -167,7 +168,7 @@ public final class BagVerifier implements AutoCloseable{
 
     logger.debug(messages.getString("checking_payload_checksums"));
     for(final Manifest payloadManifest : bag.getPayLoadManifests()){
-      checkHashes(payloadManifest, fetchUrls, isHoley);
+      checkHashes(payloadManifest, fetchUrls, holey);
     }
 
     logger.debug(messages.getString("checking_tag_file_checksums"));
@@ -184,15 +185,14 @@ public final class BagVerifier implements AutoCloseable{
     checkHashes(manifest, null, false);
   }
 
-  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-  void checkHashes(final Manifest manifest, final Map<Path, URL> fetchUrls, final boolean isHoley) throws CorruptChecksumException, InterruptedException, VerificationException{
+  void checkHashes(final Manifest manifest, final Map<Path, URL> fetchUrls, final boolean allowHoley) throws CorruptChecksumException, InterruptedException, VerificationException{
     final CountDownLatch latch = new CountDownLatch( manifest.getFileToChecksumMap().size());
 
     //TODO maybe return all of these at some point...
     final Collection<Exception> exceptions = Collections.synchronizedCollection(new ArrayList<>());
 
     for(final Entry<Path, String> entry : manifest.getFileToChecksumMap().entrySet()){
-      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions, fetchUrls, isHoley));
+      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions, fetchUrls, allowHoley));
     }
 
     latch.await();
@@ -238,12 +238,14 @@ public final class BagVerifier implements AutoCloseable{
     isComplete(bag, ignoreHiddenFiles, false);
   }
 
-  public void isComplete(final Bag bag, final boolean ignoreHiddenFiles, final boolean isHoley) throws
+  public void isComplete(final Bag bag, final boolean ignoreHiddenFiles, final boolean allowHoley) throws
     IOException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException,
     FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
     logger.info(messages.getString("checking_bag_is_complete"), bag.getRootDir());
 
-    if (!isHoley) {
+    final boolean holey = allowHoley || !bag.getItemsToFetch().isEmpty();
+
+    if (!holey) {
       MandatoryVerifier.checkFetchItemsExist(bag.getItemsToFetch(), bag.getRootDir());
     }
 
@@ -253,7 +255,7 @@ public final class BagVerifier implements AutoCloseable{
 
     MandatoryVerifier.checkIfAtLeastOnePayloadManifestsExist(bag.getRootDir(), bag.getVersion());
 
-    manifestVerifier.verifyManifests(bag, ignoreHiddenFiles, isHoley);
+    manifestVerifier.verifyManifests(bag, ignoreHiddenFiles, holey);
   }
   
   public ExecutorService getExecutor() {

--- a/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
@@ -251,7 +251,7 @@ public final class BagVerifier implements AutoCloseable{
     FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
     logger.info(messages.getString("checking_bag_is_complete"), bag.getRootDir());
 
-    final boolean holey = allowHoley || !bag.getItemsToFetch().isEmpty();
+    final boolean holey = allowHoley && !bag.getItemsToFetch().isEmpty();
 
     if (!holey) {
       MandatoryVerifier.checkFetchItemsExist(bag.getItemsToFetch(), bag.getRootDir());

--- a/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/BagVerifier.java
@@ -155,6 +155,10 @@ public final class BagVerifier implements AutoCloseable{
   }
 
   public void isValid(final Bag bag, final boolean ignoreHiddenFiles, final boolean allowHoley) throws IOException, FileNotInManifestException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, CorruptChecksumException, VerificationException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
+    isValid(bag, ignoreHiddenFiles, allowHoley, null);
+  }
+
+  public void isValid(final Bag bag, final boolean ignoreHiddenFiles, final boolean allowHoley, final Map<String, String> extraHeaders) throws IOException, FileNotInManifestException, MissingPayloadManifestException, MissingBagitFileException, MissingPayloadDirectoryException, FileNotInPayloadDirectoryException, InterruptedException, MaliciousPathException, CorruptChecksumException, VerificationException, UnsupportedAlgorithmException, InvalidBagitFileFormatException{
     logger.info(messages.getString("checking_bag_is_valid"), bag.getRootDir());
     final boolean holey = allowHoley || !bag.getItemsToFetch().isEmpty();
     isComplete(bag, ignoreHiddenFiles, holey);
@@ -168,12 +172,12 @@ public final class BagVerifier implements AutoCloseable{
 
     logger.debug(messages.getString("checking_payload_checksums"));
     for(final Manifest payloadManifest : bag.getPayLoadManifests()){
-      checkHashes(payloadManifest, fetchUrls, holey);
+      checkHashes(payloadManifest, fetchUrls, holey, extraHeaders);
     }
 
     logger.debug(messages.getString("checking_tag_file_checksums"));
     for(final Manifest tagManifest : bag.getTagManifests()){
-      checkHashes(tagManifest, null, false);
+      checkHashes(tagManifest, null, false, extraHeaders);
     }
   }
 
@@ -186,13 +190,17 @@ public final class BagVerifier implements AutoCloseable{
   }
 
   void checkHashes(final Manifest manifest, final Map<Path, URL> fetchUrls, final boolean holey) throws CorruptChecksumException, InterruptedException, VerificationException{
+    checkHashes(manifest, fetchUrls, holey, null);
+  }
+
+  void checkHashes(final Manifest manifest, final Map<Path, URL> fetchUrls, final boolean holey, final Map<String, String> extraHeaders) throws CorruptChecksumException, InterruptedException, VerificationException{
     final CountDownLatch latch = new CountDownLatch( manifest.getFileToChecksumMap().size());
 
     //TODO maybe return all of these at some point...
     final Collection<Exception> exceptions = Collections.synchronizedCollection(new ArrayList<>());
 
     for(final Entry<Path, String> entry : manifest.getFileToChecksumMap().entrySet()){
-      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions, fetchUrls, holey));
+      executor.execute(new CheckManifestHashesTask(entry, manifest.getAlgorithm().getMessageDigestName(), latch, exceptions, fetchUrls, holey, extraHeaders));
     }
 
     latch.await();

--- a/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
@@ -16,15 +16,18 @@
 package nl.knaw.dans.bagit.verify;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.concurrent.CountDownLatch;
 
+import nl.knaw.dans.bagit.domain.FetchItem;
 import nl.knaw.dans.bagit.exceptions.CorruptChecksumException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,31 +47,51 @@ public class CheckManifestHashesTask implements Runnable {
   private transient final CountDownLatch latch;
   private transient final Collection<Exception> exceptions;
   private transient final String algorithm;
-  
+  private transient final Map<Path, URL> fetchUrls;
+  private transient final boolean isHoley;
+
   public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions) {
+    this(entry, algorithm, latch, exceptions, null, false);
+  }
+
+  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, URL> fetchUrls, final boolean isHoley) {
     this.entry = entry;
     this.algorithm = algorithm;
     this.latch = latch;
     this.exceptions = exceptions;
+    this.fetchUrls = fetchUrls;
+    this.isHoley = isHoley;
   }
 
   @Override
   public void run() {
     try {
       final MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
-      checkManifestEntry(entry, messageDigest, algorithm);
+      checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, isHoley);
     } catch (IOException | CorruptChecksumException | NoSuchAlgorithmException e) {
       exceptions.add(e);
     }
     latch.countDown();
   }
-  
-  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm) throws IOException, CorruptChecksumException{
-    if(Files.exists(entry.getKey())){
+
+  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm) throws IOException, CorruptChecksumException {
+    checkManifestEntry(entry, messageDigest, algorithm, null, false);
+  }
+
+  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm, final Map<Path, URL> fetchUrls, final boolean isHoley) throws IOException, CorruptChecksumException {
+    if (Files.exists(entry.getKey())) {
       logger.debug(messages.getString("checking_checksums"), entry.getKey(), entry.getValue());
       final String hash = Hasher.hash(entry.getKey(), messageDigest);
       logger.debug("computed hash [{}] for file [{}]", hash, entry.getKey());
-      if(!hash.equals(entry.getValue())){
+      if (!hash.equals(entry.getValue())) {
+        throw new CorruptChecksumException(messages.getString("corrupt_checksum_error"), entry.getKey(), algorithm, entry.getValue(), hash);
+      }
+    } else if (isHoley && fetchUrls != null && fetchUrls.containsKey(entry.getKey())) {
+      final URL url = fetchUrls.get(entry.getKey());
+      logger.debug("File {} does not exist, but it is in fetch.txt, and isHoley is true. Hashing from URL: {}", entry.getKey(), url);
+      final String hash = Hasher.hash(url, messageDigest);
+      logger.debug("computed hash [{}] for url [{}]", hash, url);
+      if (!hash.equals(entry.getValue())) {
         throw new CorruptChecksumException(messages.getString("corrupt_checksum_error"), entry.getKey(), algorithm, entry.getValue(), hash);
       }
     }

--- a/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
@@ -48,25 +48,31 @@ public class CheckManifestHashesTask implements Runnable {
   private transient final String algorithm;
   private transient final Map<Path, URL> fetchUrls;
   private transient final boolean holey;
+  private transient final Map<String, String> extraHeaders;
 
   public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions) {
-    this(entry, algorithm, latch, exceptions, null, false);
+    this(entry, algorithm, latch, exceptions, null, false, null);
   }
 
   public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, URL> fetchUrls, final boolean holey) {
+    this(entry, algorithm, latch, exceptions, fetchUrls, holey, null);
+  }
+
+  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, URL> fetchUrls, final boolean holey, final Map<String, String> extraHeaders) {
     this.entry = entry;
     this.algorithm = algorithm;
     this.latch = latch;
     this.exceptions = exceptions;
     this.fetchUrls = fetchUrls;
     this.holey = holey;
+    this.extraHeaders = extraHeaders;
   }
 
   @Override
   public void run() {
     try {
       final MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
-      checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, holey);
+      checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, holey, extraHeaders);
     } catch (IOException | CorruptChecksumException | NoSuchAlgorithmException e) {
       exceptions.add(e);
     }
@@ -74,10 +80,14 @@ public class CheckManifestHashesTask implements Runnable {
   }
 
   protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm) throws IOException, CorruptChecksumException {
-    checkManifestEntry(entry, messageDigest, algorithm, null, false);
+    checkManifestEntry(entry, messageDigest, algorithm, null, false, null);
   }
 
   protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm, final Map<Path, URL> fetchUrls, final boolean allowHoley) throws IOException, CorruptChecksumException {
+    checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, allowHoley, null);
+  }
+
+  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm, final Map<Path, URL> fetchUrls, final boolean allowHoley, final Map<String, String> extraHeaders) throws IOException, CorruptChecksumException {
     if (Files.exists(entry.getKey())) {
       logger.debug(messages.getString("checking_checksums"), entry.getKey(), entry.getValue());
       final String hash = Hasher.hash(entry.getKey(), messageDigest);
@@ -88,7 +98,7 @@ public class CheckManifestHashesTask implements Runnable {
     } else if (allowHoley && fetchUrls != null && fetchUrls.containsKey(entry.getKey())) {
       final URL url = fetchUrls.get(entry.getKey());
       logger.debug("File {} does not exist, but it is in fetch.txt, and allowHoley is true. Hashing from URL: {}", entry.getKey(), url);
-      final String hash = Hasher.hash(url, messageDigest);
+      final String hash = Hasher.hash(url, messageDigest, extraHeaders);
       logger.debug("computed hash [{}] for url [{}]", hash, url);
       if (!hash.equals(entry.getValue())) {
         throw new CorruptChecksumException(messages.getString("corrupt_checksum_error"), entry.getKey(), algorithm, entry.getValue(), hash);

--- a/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
@@ -27,6 +27,7 @@ import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.concurrent.CountDownLatch;
 
+import nl.knaw.dans.bagit.domain.FetchItem;
 import nl.knaw.dans.bagit.exceptions.CorruptChecksumException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +47,7 @@ public class CheckManifestHashesTask implements Runnable {
   private transient final CountDownLatch latch;
   private transient final Collection<Exception> exceptions;
   private transient final String algorithm;
-  private transient final Map<Path, URL> fetchUrls;
+  private transient final Map<Path, FetchItem> fetchItems;
   private transient final boolean holey;
   private transient final Map<String, String> extraHeaders;
 
@@ -54,16 +55,16 @@ public class CheckManifestHashesTask implements Runnable {
     this(entry, algorithm, latch, exceptions, null, false, null);
   }
 
-  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, URL> fetchUrls, final boolean holey) {
-    this(entry, algorithm, latch, exceptions, fetchUrls, holey, null);
+  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, FetchItem> fetchItems, final boolean holey) {
+    this(entry, algorithm, latch, exceptions, fetchItems, holey, null);
   }
 
-  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, URL> fetchUrls, final boolean holey, final Map<String, String> extraHeaders) {
+  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, FetchItem> fetchItems, final boolean holey, final Map<String, String> extraHeaders) {
     this.entry = entry;
     this.algorithm = algorithm;
     this.latch = latch;
     this.exceptions = exceptions;
-    this.fetchUrls = fetchUrls;
+    this.fetchItems = fetchItems;
     this.holey = holey;
     this.extraHeaders = extraHeaders;
   }
@@ -72,7 +73,7 @@ public class CheckManifestHashesTask implements Runnable {
   public void run() {
     try {
       final MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
-      checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, holey, extraHeaders);
+      checkManifestEntry(entry, messageDigest, algorithm, fetchItems, holey, extraHeaders);
     } catch (IOException | CorruptChecksumException | NoSuchAlgorithmException e) {
       exceptions.add(e);
     }
@@ -83,11 +84,11 @@ public class CheckManifestHashesTask implements Runnable {
     checkManifestEntry(entry, messageDigest, algorithm, null, false, null);
   }
 
-  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm, final Map<Path, URL> fetchUrls, final boolean allowHoley) throws IOException, CorruptChecksumException {
-    checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, allowHoley, null);
+  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm, final Map<Path, FetchItem> fetchItems, final boolean allowHoley) throws IOException, CorruptChecksumException {
+    checkManifestEntry(entry, messageDigest, algorithm, fetchItems, allowHoley, null);
   }
 
-  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm, final Map<Path, URL> fetchUrls, final boolean allowHoley, final Map<String, String> extraHeaders) throws IOException, CorruptChecksumException {
+  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm, final Map<Path, FetchItem> fetchItems, final boolean allowHoley, final Map<String, String> extraHeaders) throws IOException, CorruptChecksumException {
     if (Files.exists(entry.getKey())) {
       logger.debug(messages.getString("checking_checksums"), entry.getKey(), entry.getValue());
       final String hash = Hasher.hash(entry.getKey(), messageDigest);
@@ -95,11 +96,11 @@ public class CheckManifestHashesTask implements Runnable {
       if (!hash.equals(entry.getValue())) {
         throw new CorruptChecksumException(messages.getString("corrupt_checksum_error"), entry.getKey(), algorithm, entry.getValue(), hash);
       }
-    } else if (allowHoley && fetchUrls != null && fetchUrls.containsKey(entry.getKey())) {
-      final URL url = fetchUrls.get(entry.getKey());
-      logger.debug("File {} does not exist, but it is in fetch.txt, and allowHoley is true. Hashing from URL: {}", entry.getKey(), url);
-      final String hash = Hasher.hash(url, messageDigest, extraHeaders);
-      logger.debug("computed hash [{}] for url [{}]", hash, url);
+    } else if (allowHoley && fetchItems != null && fetchItems.containsKey(entry.getKey())) {
+      final FetchItem item = fetchItems.get(entry.getKey());
+      logger.debug("File {} does not exist, but it is in fetch.txt, and allowHoley is true. Hashing from URL: {}", entry.getKey(), item.url);
+      final String hash = Hasher.hash(item, messageDigest, extraHeaders);
+      logger.debug("computed hash [{}] for url [{}]", hash, item.url);
       if (!hash.equals(entry.getValue())) {
         throw new CorruptChecksumException(messages.getString("corrupt_checksum_error"), entry.getKey(), algorithm, entry.getValue(), hash);
       }

--- a/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
@@ -27,7 +27,6 @@ import java.util.Map.Entry;
 import java.util.ResourceBundle;
 import java.util.concurrent.CountDownLatch;
 
-import nl.knaw.dans.bagit.domain.FetchItem;
 import nl.knaw.dans.bagit.exceptions.CorruptChecksumException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,26 +47,26 @@ public class CheckManifestHashesTask implements Runnable {
   private transient final Collection<Exception> exceptions;
   private transient final String algorithm;
   private transient final Map<Path, URL> fetchUrls;
-  private transient final boolean isHoley;
+  private transient final boolean allowHoley;
 
   public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions) {
     this(entry, algorithm, latch, exceptions, null, false);
   }
 
-  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, URL> fetchUrls, final boolean isHoley) {
+  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, URL> fetchUrls, final boolean allowHoley) {
     this.entry = entry;
     this.algorithm = algorithm;
     this.latch = latch;
     this.exceptions = exceptions;
     this.fetchUrls = fetchUrls;
-    this.isHoley = isHoley;
+    this.allowHoley = allowHoley;
   }
 
   @Override
   public void run() {
     try {
       final MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
-      checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, isHoley);
+      checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, allowHoley);
     } catch (IOException | CorruptChecksumException | NoSuchAlgorithmException e) {
       exceptions.add(e);
     }
@@ -78,7 +77,7 @@ public class CheckManifestHashesTask implements Runnable {
     checkManifestEntry(entry, messageDigest, algorithm, null, false);
   }
 
-  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm, final Map<Path, URL> fetchUrls, final boolean isHoley) throws IOException, CorruptChecksumException {
+  protected static void checkManifestEntry(final Entry<Path, String> entry, final MessageDigest messageDigest, final String algorithm, final Map<Path, URL> fetchUrls, final boolean allowHoley) throws IOException, CorruptChecksumException {
     if (Files.exists(entry.getKey())) {
       logger.debug(messages.getString("checking_checksums"), entry.getKey(), entry.getValue());
       final String hash = Hasher.hash(entry.getKey(), messageDigest);
@@ -86,9 +85,9 @@ public class CheckManifestHashesTask implements Runnable {
       if (!hash.equals(entry.getValue())) {
         throw new CorruptChecksumException(messages.getString("corrupt_checksum_error"), entry.getKey(), algorithm, entry.getValue(), hash);
       }
-    } else if (isHoley && fetchUrls != null && fetchUrls.containsKey(entry.getKey())) {
+    } else if (allowHoley && fetchUrls != null && fetchUrls.containsKey(entry.getKey())) {
       final URL url = fetchUrls.get(entry.getKey());
-      logger.debug("File {} does not exist, but it is in fetch.txt, and isHoley is true. Hashing from URL: {}", entry.getKey(), url);
+      logger.debug("File {} does not exist, but it is in fetch.txt, and allowHoley is true. Hashing from URL: {}", entry.getKey(), url);
       final String hash = Hasher.hash(url, messageDigest);
       logger.debug("computed hash [{}] for url [{}]", hash, url);
       if (!hash.equals(entry.getValue())) {

--- a/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/CheckManifestHashesTask.java
@@ -47,26 +47,26 @@ public class CheckManifestHashesTask implements Runnable {
   private transient final Collection<Exception> exceptions;
   private transient final String algorithm;
   private transient final Map<Path, URL> fetchUrls;
-  private transient final boolean allowHoley;
+  private transient final boolean holey;
 
   public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions) {
     this(entry, algorithm, latch, exceptions, null, false);
   }
 
-  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, URL> fetchUrls, final boolean allowHoley) {
+  public CheckManifestHashesTask(final Entry<Path, String> entry, final String algorithm, final CountDownLatch latch, final Collection<Exception> exceptions, final Map<Path, URL> fetchUrls, final boolean holey) {
     this.entry = entry;
     this.algorithm = algorithm;
     this.latch = latch;
     this.exceptions = exceptions;
     this.fetchUrls = fetchUrls;
-    this.allowHoley = allowHoley;
+    this.holey = holey;
   }
 
   @Override
   public void run() {
     try {
       final MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
-      checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, allowHoley);
+      checkManifestEntry(entry, messageDigest, algorithm, fetchUrls, holey);
     } catch (IOException | CorruptChecksumException | NoSuchAlgorithmException e) {
       exceptions.add(e);
     }

--- a/src/main/java/nl/knaw/dans/bagit/verify/ManifestVerifier.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/ManifestVerifier.java
@@ -17,7 +17,6 @@ package nl.knaw.dans.bagit.verify;
 
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -36,7 +35,6 @@ import nl.knaw.dans.bagit.exceptions.FileNotInPayloadDirectoryException;
 import nl.knaw.dans.bagit.exceptions.InvalidBagitFileFormatException;
 import nl.knaw.dans.bagit.exceptions.MaliciousPathException;
 import nl.knaw.dans.bagit.exceptions.UnsupportedAlgorithmException;
-import nl.knaw.dans.bagit.reader.ManifestReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.MessageFormatter;
@@ -135,7 +133,7 @@ public class ManifestVerifier implements AutoCloseable{
     verifyManifests(bag, ignoreHiddenFiles, false);
   }
 
-  public void verifyManifests(final Bag bag, final boolean ignoreHiddenFiles, final boolean isHoley)
+  public void verifyManifests(final Bag bag, final boolean ignoreHiddenFiles, final boolean allowHoley)
       throws IOException, MaliciousPathException, UnsupportedAlgorithmException,
       InvalidBagitFileFormatException, FileNotInPayloadDirectoryException, InterruptedException {
 
@@ -145,7 +143,7 @@ public class ManifestVerifier implements AutoCloseable{
     final Set<Path> payloadFiles = getFilesListedInPayloadManifests(bag);
     final Set<Path> tagFiles = getFilesListedInTagManifests(bag);
 
-    checkAllFilesListedInManifestExist(payloadFiles, isHoley, bag);
+    checkAllFilesListedInManifestExist(payloadFiles, allowHoley, bag);
     checkAllFilesListedInManifestExist(tagFiles, false, bag);
 
     final Set<Path> allFilesListedInManifests = new HashSet<>(payloadFiles);
@@ -200,12 +198,12 @@ public class ManifestVerifier implements AutoCloseable{
    * Make sure all the listed files actually exist
    */
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-  private void checkAllFilesListedInManifestExist(final Set<Path> files, final boolean isHoley, final Bag bag) throws FileNotInPayloadDirectoryException, InterruptedException {
+  private void checkAllFilesListedInManifestExist(final Set<Path> files, final boolean allowHoley, final Bag bag) throws FileNotInPayloadDirectoryException, InterruptedException {
     final CountDownLatch latch = new CountDownLatch(files.size());
     final Set<Path> missingFiles = new ConcurrentSkipListSet<>();
 
     final Map<Path, URL> fetchUrls = new HashMap<>();
-    if (isHoley) {
+    if (allowHoley) {
       for (final FetchItem item : bag.getItemsToFetch()) {
         fetchUrls.put(item.path, item.url);
       }
@@ -213,7 +211,7 @@ public class ManifestVerifier implements AutoCloseable{
 
     logger.info(messages.getString("check_all_files_in_manifests_exist"));
     for (final Path file : files) {
-      if (isHoley && fetchUrls.containsKey(file)) {
+      if (allowHoley && fetchUrls.containsKey(file)) {
         latch.countDown();
       } else {
         executor.execute(new CheckIfFileExistsTask(file, missingFiles, latch));

--- a/src/main/java/nl/knaw/dans/bagit/verify/ManifestVerifier.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/ManifestVerifier.java
@@ -133,7 +133,7 @@ public class ManifestVerifier implements AutoCloseable{
     verifyManifests(bag, ignoreHiddenFiles, false);
   }
 
-  public void verifyManifests(final Bag bag, final boolean ignoreHiddenFiles, final boolean allowHoley)
+  public void verifyManifests(final Bag bag, final boolean ignoreHiddenFiles, final boolean holey)
       throws IOException, MaliciousPathException, UnsupportedAlgorithmException,
       InvalidBagitFileFormatException, FileNotInPayloadDirectoryException, InterruptedException {
 
@@ -143,7 +143,7 @@ public class ManifestVerifier implements AutoCloseable{
     final Set<Path> payloadFiles = getFilesListedInPayloadManifests(bag);
     final Set<Path> tagFiles = getFilesListedInTagManifests(bag);
 
-    checkAllFilesListedInManifestExist(payloadFiles, allowHoley, bag);
+    checkAllFilesListedInManifestExist(payloadFiles, holey, bag);
     checkAllFilesListedInManifestExist(tagFiles, false, bag);
 
     final Set<Path> allFilesListedInManifests = new HashSet<>(payloadFiles);
@@ -152,7 +152,7 @@ public class ManifestVerifier implements AutoCloseable{
     if (bag.getVersion().isOlder(new Version(1, 0))) {
       checkAllFilesInPayloadDirAreListedInAtLeastOneAManifest(allFilesListedInManifests, PathUtils.getDataDir(bag), ignoreHiddenFiles);
     } else {
-      CheckAllFilesInPayloadDirAreListedInAllManifests(bag.getPayLoadManifests(), PathUtils.getDataDir(bag), ignoreHiddenFiles);
+      checkAllFilesInPayloadDirAreListedInAllManifests(bag.getPayLoadManifests(), PathUtils.getDataDir(bag), ignoreHiddenFiles);
     }
   }
 
@@ -198,12 +198,12 @@ public class ManifestVerifier implements AutoCloseable{
    * Make sure all the listed files actually exist
    */
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-  private void checkAllFilesListedInManifestExist(final Set<Path> files, final boolean allowHoley, final Bag bag) throws FileNotInPayloadDirectoryException, InterruptedException {
+  private void checkAllFilesListedInManifestExist(final Set<Path> files, final boolean holey, final Bag bag) throws FileNotInPayloadDirectoryException, InterruptedException {
     final CountDownLatch latch = new CountDownLatch(files.size());
     final Set<Path> missingFiles = new ConcurrentSkipListSet<>();
 
     final Map<Path, URL> fetchUrls = new HashMap<>();
-    if (allowHoley) {
+    if (holey) {
       for (final FetchItem item : bag.getItemsToFetch()) {
         fetchUrls.put(item.path, item.url);
       }
@@ -211,7 +211,8 @@ public class ManifestVerifier implements AutoCloseable{
 
     logger.info(messages.getString("check_all_files_in_manifests_exist"));
     for (final Path file : files) {
-      if (allowHoley && fetchUrls.containsKey(file)) {
+      if (holey && fetchUrls.containsKey(file)) {
+        // Not actually checking that the file can be downloaded. That will be done when calculating the checksums later on.
         latch.countDown();
       } else {
         executor.execute(new CheckIfFileExistsTask(file, missingFiles, latch));
@@ -249,7 +250,7 @@ public class ManifestVerifier implements AutoCloseable{
   /*
    * as per the bagit-spec 1.0+ all files have to be listed in all manifests
    */
-  private static void CheckAllFilesInPayloadDirAreListedInAllManifests(final Set<Manifest> payLoadManifests,
+  private static void checkAllFilesInPayloadDirAreListedInAllManifests(final Set<Manifest> payLoadManifests,
       final Path payloadDir, final boolean ignoreHiddenFiles) throws IOException {
     logger.debug(messages.getString("checking_file_in_all_manifests"), payloadDir);
     if (Files.exists(payloadDir)) {

--- a/src/main/java/nl/knaw/dans/bagit/verify/ManifestVerifier.java
+++ b/src/main/java/nl/knaw/dans/bagit/verify/ManifestVerifier.java
@@ -16,10 +16,13 @@
 package nl.knaw.dans.bagit.verify;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -28,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import nl.knaw.dans.bagit.domain.Bag;
+import nl.knaw.dans.bagit.domain.FetchItem;
 import nl.knaw.dans.bagit.exceptions.FileNotInPayloadDirectoryException;
 import nl.knaw.dans.bagit.exceptions.InvalidBagitFileFormatException;
 import nl.knaw.dans.bagit.exceptions.MaliciousPathException;
@@ -111,12 +115,41 @@ public class ManifestVerifier implements AutoCloseable{
    * @throws FileNotInPayloadDirectoryException if a file is listed in a manifest but doesn't exist in the payload directory
    * @throws InterruptedException if a thread is interrupted while doing work
    */
+  /*
+   * Verify that all the files in the payload directory are listed in the payload manifest and 
+   * all files listed in all manifests exist.
+   * 
+   * @param bag the bag to check to check
+   * @param ignoreHiddenFiles to ignore hidden files unless they are specifically listed in a manifest
+   * 
+   * @throws IOException if there is a problem reading a file
+   * @throws MaliciousPathException the path in the manifest was specifically crafted to cause harm
+   * @throws UnsupportedAlgorithmException if the algorithm used for the manifest is unsupported
+   * @throws InvalidBagitFileFormatException if any of the manifests don't conform to the bagit specification
+   * @throws FileNotInPayloadDirectoryException if a file is listed in a manifest but doesn't exist in the payload directory
+   * @throws InterruptedException if a thread is interrupted while doing work
+   */
   public void verifyManifests(final Bag bag, final boolean ignoreHiddenFiles)
       throws IOException, MaliciousPathException, UnsupportedAlgorithmException, 
       InvalidBagitFileFormatException, FileNotInPayloadDirectoryException, InterruptedException {
-    
-    final Set<Path> allFilesListedInManifests = getAllFilesListedInManifests(bag);
-    checkAllFilesListedInManifestExist(allFilesListedInManifests);
+    verifyManifests(bag, ignoreHiddenFiles, false);
+  }
+
+  public void verifyManifests(final Bag bag, final boolean ignoreHiddenFiles, final boolean isHoley)
+      throws IOException, MaliciousPathException, UnsupportedAlgorithmException,
+      InvalidBagitFileFormatException, FileNotInPayloadDirectoryException, InterruptedException {
+
+    checkAlgorithms(bag.getPayLoadManifests());
+    checkAlgorithms(bag.getTagManifests());
+
+    final Set<Path> payloadFiles = getFilesListedInPayloadManifests(bag);
+    final Set<Path> tagFiles = getFilesListedInTagManifests(bag);
+
+    checkAllFilesListedInManifestExist(payloadFiles, isHoley, bag);
+    checkAllFilesListedInManifestExist(tagFiles, false, bag);
+
+    final Set<Path> allFilesListedInManifests = new HashSet<>(payloadFiles);
+    allFilesListedInManifests.addAll(tagFiles);
 
     if (bag.getVersion().isOlder(new Version(1, 0))) {
       checkAllFilesInPayloadDirAreListedInAtLeastOneAManifest(allFilesListedInManifests, PathUtils.getDataDir(bag), ignoreHiddenFiles);
@@ -125,25 +158,39 @@ public class ManifestVerifier implements AutoCloseable{
     }
   }
 
+  private void checkAlgorithms(final Set<Manifest> manifests) throws UnsupportedAlgorithmException {
+    for (final Manifest manifest : manifests) {
+      if (nameMapping.getSupportedAlgorithm(manifest.getAlgorithm().getBagitName()) == null) {
+        throw new UnsupportedAlgorithmException(messages.getString("unsupported_algorithm_error"), manifest.getAlgorithm().getBagitName(), null);
+      }
+    }
+  }
+
   /*
-   * get all the files listed in all the manifests
+   * get all the files listed in the payload manifests
    */
-  private Set<Path> getAllFilesListedInManifests(final Bag bag)
+  private Set<Path> getFilesListedInPayloadManifests(final Bag bag)
       throws IOException, MaliciousPathException, UnsupportedAlgorithmException, InvalidBagitFileFormatException {
     logger.debug(messages.getString("all_files_in_manifests"));
     final Set<Path> filesListedInManifests = new HashSet<>();
 
-    try(DirectoryStream<Path> directoryStream = 
-        Files.newDirectoryStream(PathUtils.getBagitDir(bag.getVersion(), bag.getRootDir()))){
-      for (final Path path : directoryStream) {
-        final String filename = PathUtils.getFilename(path);
-        if (filename.startsWith("tagmanifest-") || filename.startsWith("manifest-")) {
-          logger.debug(messages.getString("get_listing_in_manifest"), path);
-          final Manifest manifest = ManifestReader.readManifest(nameMapping, path, bag.getRootDir(),
-              bag.getFileEncoding());
-          filesListedInManifests.addAll(manifest.getFileToChecksumMap().keySet());
-        }
-      }
+    for (final Manifest manifest : bag.getPayLoadManifests()) {
+      filesListedInManifests.addAll(manifest.getFileToChecksumMap().keySet());
+    }
+
+    return filesListedInManifests;
+  }
+
+  /*
+   * get all the files listed in the tag manifests
+   */
+  private Set<Path> getFilesListedInTagManifests(final Bag bag)
+      throws IOException, MaliciousPathException, UnsupportedAlgorithmException, InvalidBagitFileFormatException {
+    logger.debug(messages.getString("all_files_in_manifests"));
+    final Set<Path> filesListedInManifests = new HashSet<>();
+
+    for (final Manifest manifest : bag.getTagManifests()) {
+      filesListedInManifests.addAll(manifest.getFileToChecksumMap().keySet());
     }
 
     return filesListedInManifests;
@@ -153,13 +200,24 @@ public class ManifestVerifier implements AutoCloseable{
    * Make sure all the listed files actually exist
    */
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-  private void checkAllFilesListedInManifestExist(final Set<Path> files) throws FileNotInPayloadDirectoryException, InterruptedException {
+  private void checkAllFilesListedInManifestExist(final Set<Path> files, final boolean isHoley, final Bag bag) throws FileNotInPayloadDirectoryException, InterruptedException {
     final CountDownLatch latch = new CountDownLatch(files.size());
     final Set<Path> missingFiles = new ConcurrentSkipListSet<>();
 
+    final Map<Path, URL> fetchUrls = new HashMap<>();
+    if (isHoley) {
+      for (final FetchItem item : bag.getItemsToFetch()) {
+        fetchUrls.put(item.path, item.url);
+      }
+    }
+
     logger.info(messages.getString("check_all_files_in_manifests_exist"));
     for (final Path file : files) {
-      executor.execute(new CheckIfFileExistsTask(file, missingFiles, latch));
+      if (isHoley && fetchUrls.containsKey(file)) {
+        latch.countDown();
+      } else {
+        executor.execute(new CheckIfFileExistsTask(file, missingFiles, latch));
+      }
     }
 
     latch.await();
@@ -168,6 +226,14 @@ public class ManifestVerifier implements AutoCloseable{
       final String formattedMessage = messages.getString("missing_payload_files_error");
       throw new FileNotInPayloadDirectoryException(MessageFormatter.format(formattedMessage, missingFiles).getMessage());
     }
+  }
+
+  /*
+   * Make sure all the listed files actually exist
+   */
+  @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+  private void checkAllFilesListedInManifestExist(final Set<Path> files) throws FileNotInPayloadDirectoryException, InterruptedException {
+    checkAllFilesListedInManifestExist(files, false, null);
   }
 
   /*

--- a/src/test/java/nl/knaw/dans/bagit/hash/HasherUrlTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/hash/HasherUrlTest.java
@@ -208,6 +208,44 @@ public class HasherUrlTest {
     }
 
     @Test
+    public void testHashWithFailedHeadRequest() throws IOException, NoSuchAlgorithmException {
+        server.removeContext("/test");
+        server.createContext("/test", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                requestCount.incrementAndGet();
+                if ("HEAD".equals(exchange.getRequestMethod())) {
+                    exchange.sendResponseHeaders(405, -1);
+                } else {
+                    exchange.getResponseHeaders().set("Content-Length", String.valueOf(TEST_DATA_BYTES.length));
+                    exchange.sendResponseHeaders(200, TEST_DATA_BYTES.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(TEST_DATA_BYTES);
+                    }
+                }
+            }
+        });
+
+        URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/test");
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+
+        String hash = Hasher.hash(url, md);
+
+        MessageDigest expectedMd = MessageDigest.getInstance("SHA-1");
+        expectedMd.update(TEST_DATA_BYTES);
+        byte[] digest = expectedMd.digest();
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        String expectedHash = sb.toString();
+
+        Assertions.assertEquals(expectedHash, hash);
+        // Expect 2 requests: 1 HEAD (failed) and 1 GET (fallback)
+        Assertions.assertEquals(2, requestCount.get());
+    }
+
+    @Test
     public void testHashWithFileUrl() throws IOException, NoSuchAlgorithmException {
         java.nio.file.Path tempFile = java.nio.file.Files.createTempFile("hasher-file-url-test", ".txt");
         try {

--- a/src/test/java/nl/knaw/dans/bagit/hash/HasherUrlTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/hash/HasherUrlTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.bagit.hash;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class HasherUrlTest {
+
+    private HttpServer server;
+    private static final String TEST_DATA = "This is some test data that should be hashed correctly even with retries and range requests.";
+    private static final byte[] TEST_DATA_BYTES = TEST_DATA.getBytes(StandardCharsets.UTF_8);
+    private AtomicInteger requestCount = new AtomicInteger(0);
+
+    @BeforeEach
+    public void setup() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/test", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                requestCount.incrementAndGet();
+                String range = exchange.getRequestHeaders().getFirst("Range");
+                
+                if (range == null) {
+                    // Full request
+                    exchange.getResponseHeaders().set("Accept-Ranges", "bytes");
+                    exchange.getResponseHeaders().set("Content-Length", String.valueOf(TEST_DATA_BYTES.length));
+                    exchange.sendResponseHeaders(200, TEST_DATA_BYTES.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(TEST_DATA_BYTES);
+                    }
+                } else if (range.startsWith("bytes=")) {
+                    // Range request
+                    String[] parts = range.substring(6).split("-");
+                    int start = Integer.parseInt(parts[0]);
+                    int end = parts.length > 1 && !parts[1].isEmpty() ? Integer.parseInt(parts[1]) : TEST_DATA_BYTES.length - 1;
+                    
+                    if (start >= TEST_DATA_BYTES.length) {
+                        exchange.sendResponseHeaders(416, -1);
+                        return;
+                    }
+                    
+                    int length = end - start + 1;
+                    exchange.getResponseHeaders().set("Content-Range", "bytes " + start + "-" + end + "/" + TEST_DATA_BYTES.length);
+                    exchange.sendResponseHeaders(206, length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(TEST_DATA_BYTES, start, length);
+                    }
+                } else {
+                    exchange.sendResponseHeaders(400, -1);
+                }
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    public void teardown() {
+        if (server != null) {
+            server.stop(0);
+        }
+        System.clearProperty("nl.knaw.dans.bagit.hash.chunkSize");
+        System.clearProperty("nl.knaw.dans.bagit.hash.maxRetries");
+        System.clearProperty("nl.knaw.dans.bagit.hash.retrySleepMs");
+    }
+
+    @Test
+    public void testHashWithRangeRequests() throws IOException, NoSuchAlgorithmException {
+        System.setProperty("nl.knaw.dans.bagit.hash.chunkSize", "10");
+        URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/test");
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        
+        String hash = Hasher.hash(url, md);
+        
+        // Expected SHA-1 of TEST_DATA
+        MessageDigest expectedMd = MessageDigest.getInstance("SHA-1");
+        expectedMd.update(TEST_DATA_BYTES);
+        byte[] digest = expectedMd.digest();
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        String expectedHash = sb.toString();
+        
+        Assertions.assertEquals(expectedHash, hash);
+        // With chunk size 10 and total length ~90, we expect around 10-11 requests (1 HEAD/initial + chunks)
+        Assertions.assertTrue(requestCount.get() > 1);
+    }
+
+    @Test
+    public void testHashWithRetries() throws IOException, NoSuchAlgorithmException {
+        server.removeContext("/test");
+        AtomicInteger failCount = new AtomicInteger(0);
+        server.createContext("/test", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                int count = requestCount.incrementAndGet();
+                if (count == 2 || count == 3) {
+                    // Fail the second and third request (first chunk requests)
+                    exchange.sendResponseHeaders(500, -1);
+                    return;
+                }
+                
+                String range = exchange.getRequestHeaders().getFirst("Range");
+                if (range == null) {
+                    exchange.getResponseHeaders().set("Accept-Ranges", "bytes");
+                    exchange.getResponseHeaders().set("Content-Length", String.valueOf(TEST_DATA_BYTES.length));
+                    exchange.sendResponseHeaders(200, TEST_DATA_BYTES.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(TEST_DATA_BYTES);
+                    }
+                } else {
+                    String[] parts = range.substring(6).split("-");
+                    int start = Integer.parseInt(parts[0]);
+                    int end = parts.length > 1 && !parts[1].isEmpty() ? Integer.parseInt(parts[1]) : TEST_DATA_BYTES.length - 1;
+                    int length = end - start + 1;
+                    exchange.getResponseHeaders().set("Content-Range", "bytes " + start + "-" + end + "/" + TEST_DATA_BYTES.length);
+                    exchange.sendResponseHeaders(206, length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(TEST_DATA_BYTES, start, length);
+                    }
+                }
+            }
+        });
+
+        System.setProperty("nl.knaw.dans.bagit.hash.chunkSize", "20");
+        System.setProperty("nl.knaw.dans.bagit.hash.maxRetries", "3");
+        System.setProperty("nl.knaw.dans.bagit.hash.retrySleepMs", "100");
+        
+        URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/test");
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        
+        String hash = Hasher.hash(url, md);
+        
+        MessageDigest expectedMd = MessageDigest.getInstance("SHA-1");
+        expectedMd.update(TEST_DATA_BYTES);
+        byte[] digest = expectedMd.digest();
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        String expectedHash = sb.toString();
+        
+        Assertions.assertEquals(expectedHash, hash);
+        Assertions.assertTrue(requestCount.get() >= 5); // 1 initial + 2 failed + successful chunks
+    }
+
+    @Test
+    public void testHashWithoutRangeSupport() throws IOException, NoSuchAlgorithmException {
+        server.removeContext("/test");
+        server.createContext("/test", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                requestCount.incrementAndGet();
+                // No Accept-Ranges header
+                exchange.getResponseHeaders().set("Content-Length", String.valueOf(TEST_DATA_BYTES.length));
+                exchange.sendResponseHeaders(200, TEST_DATA_BYTES.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(TEST_DATA_BYTES);
+                }
+            }
+        });
+
+        URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/test");
+        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        
+        String hash = Hasher.hash(url, md);
+        
+        MessageDigest expectedMd = MessageDigest.getInstance("SHA-1");
+        expectedMd.update(TEST_DATA_BYTES);
+        byte[] digest = expectedMd.digest();
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        String expectedHash = sb.toString();
+        
+        Assertions.assertEquals(expectedHash, hash);
+        // Only 2 requests: 1 HEAD and 1 for full content (openStream)
+        Assertions.assertEquals(2, requestCount.get());
+    }
+
+    @Test
+    public void testHashWithFileUrl() throws IOException, NoSuchAlgorithmException {
+        java.nio.file.Path tempFile = java.nio.file.Files.createTempFile("hasher-file-url-test", ".txt");
+        try {
+            java.nio.file.Files.write(tempFile, TEST_DATA_BYTES);
+            URL fileUrl = tempFile.toUri().toURL();
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+
+            String hash = Hasher.hash(fileUrl, md);
+
+            MessageDigest expectedMd = MessageDigest.getInstance("SHA-1");
+            expectedMd.update(TEST_DATA_BYTES);
+            byte[] digest = expectedMd.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            String expectedHash = sb.toString();
+
+            Assertions.assertEquals(expectedHash, hash);
+        } finally {
+            java.nio.file.Files.deleteIfExists(tempFile);
+        }
+    }
+}

--- a/src/test/java/nl/knaw/dans/bagit/hash/HasherUrlTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/hash/HasherUrlTest.java
@@ -203,18 +203,19 @@ public class HasherUrlTest {
         String expectedHash = sb.toString();
         
         Assertions.assertEquals(expectedHash, hash);
-        // Only 2 requests: 1 HEAD and 1 for full content (openStream)
-        Assertions.assertEquals(2, requestCount.get());
+        // Only 1 request: the first range request which returns 200 OK and is treated as the full stream
+        Assertions.assertEquals(1, requestCount.get());
     }
 
     @Test
-    public void testHashWithFailedHeadRequest() throws IOException, NoSuchAlgorithmException {
+    public void testHashWithFailedFirstRangeRequest() throws IOException, NoSuchAlgorithmException {
         server.removeContext("/test");
         server.createContext("/test", new HttpHandler() {
             @Override
             public void handle(HttpExchange exchange) throws IOException {
                 requestCount.incrementAndGet();
-                if ("HEAD".equals(exchange.getRequestMethod())) {
+                if (exchange.getRequestHeaders().containsKey("Range")) {
+                    // Fail range request after 5 attempts (to trigger fallback)
                     exchange.sendResponseHeaders(405, -1);
                 } else {
                     exchange.getResponseHeaders().set("Content-Length", String.valueOf(TEST_DATA_BYTES.length));
@@ -226,23 +227,28 @@ public class HasherUrlTest {
             }
         });
 
-        URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/test");
-        MessageDigest md = MessageDigest.getInstance("SHA-1");
+        System.setProperty("nl.knaw.dans.bagit.hash.maxRetries", "1");
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/test");
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
 
-        String hash = Hasher.hash(url, md);
+            String hash = Hasher.hash(url, md);
 
-        MessageDigest expectedMd = MessageDigest.getInstance("SHA-1");
-        expectedMd.update(TEST_DATA_BYTES);
-        byte[] digest = expectedMd.digest();
-        StringBuilder sb = new StringBuilder();
-        for (byte b : digest) {
-            sb.append(String.format("%02x", b));
+            MessageDigest expectedMd = MessageDigest.getInstance("SHA-1");
+            expectedMd.update(TEST_DATA_BYTES);
+            byte[] digest = expectedMd.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b));
+            }
+            String expectedHash = sb.toString();
+
+            Assertions.assertEquals(expectedHash, hash);
+            // Expect 2 requests: 1 range request (failed) and 1 GET (fallback to full stream)
+            Assertions.assertEquals(2, requestCount.get());
+        } finally {
+            System.clearProperty("nl.knaw.dans.bagit.hash.maxRetries");
         }
-        String expectedHash = sb.toString();
-
-        Assertions.assertEquals(expectedHash, hash);
-        // Expect 2 requests: 1 HEAD (failed) and 1 GET (fallback)
-        Assertions.assertEquals(2, requestCount.get());
     }
 
     @Test

--- a/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierRedirectTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierRedirectTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.bagit.verify;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import nl.knaw.dans.bagit.TempFolderTest;
+import nl.knaw.dans.bagit.domain.Bag;
+import nl.knaw.dans.bagit.reader.BagReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class BagVerifierRedirectTest extends TempFolderTest {
+    private HttpServer server1;
+    private HttpServer server2;
+    private BagVerifier sut;
+    private BagReader reader;
+    private int port1;
+    private int port2;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        sut = new BagVerifier();
+        reader = new BagReader();
+        
+        server1 = HttpServer.create(new InetSocketAddress(0), 0);
+        server1.setExecutor(null);
+        server1.start();
+        port1 = server1.getAddress().getPort();
+
+        server2 = HttpServer.create(new InetSocketAddress(0), 0);
+        server2.setExecutor(null);
+        server2.start();
+        port2 = server2.getAddress().getPort();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (server1 != null) server1.stop(0);
+        if (server2 != null) server2.stop(0);
+        if (sut != null) sut.close();
+    }
+
+    @Test
+    public void testRedirectStripsHeadersOnHostChange() throws Exception {
+        final String content = "final content";
+        final String authHeaderName = "X-Dataverse-key";
+        final String authHeaderValue = "secret";
+        final AtomicBoolean headersSentToServer2 = new AtomicBoolean(false);
+
+        // Server 1 redirects to Server 2
+        server1.createContext("/api/access/datafile/1", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                System.out.println("[DEBUG_LOG] Server 1 received request with headers: " + exchange.getRequestHeaders().entrySet());
+                if (authHeaderValue.equals(exchange.getRequestHeaders().getFirst(authHeaderName))) {
+                    exchange.getResponseHeaders().set("Location", "http://localhost:" + port2 + "/storage/file1?token=xyz");
+                    exchange.sendResponseHeaders(302, -1);
+                } else {
+                    exchange.sendResponseHeaders(401, -1);
+                }
+            }
+        });
+
+        // Server 2 returns content but fails if auth header is present
+        server2.createContext("/storage/file1", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                System.out.println("[DEBUG_LOG] Server 2 received request with headers: " + exchange.getRequestHeaders().entrySet());
+                if (exchange.getRequestHeaders().containsKey(authHeaderName)) {
+                    headersSentToServer2.set(true);
+                    // Simulate 403 Forbidden because S3 rejects requests with unknown/extra auth headers
+                    exchange.sendResponseHeaders(403, -1);
+                } else {
+                    byte[] response = content.getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(200, response.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(response);
+                    }
+                }
+            }
+        });
+
+        Path bagDir = Files.createTempDirectory(folder, "redirect-headers-bag");
+        Files.write(bagDir.resolve("bagit.txt"), "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n".getBytes());
+        Files.createDirectory(bagDir.resolve("data"));
+        
+        MessageDigest md5 = MessageDigest.getInstance("MD5");
+        md5.update(content.getBytes(StandardCharsets.UTF_8));
+        String hash = formatMessageDigest(md5.digest());
+        
+        Files.write(bagDir.resolve("manifest-md5.txt"), (hash + "  data/test.txt\n").getBytes());
+        
+        URL remoteUrl = new URL("http://localhost:" + port1 + "/api/access/datafile/1");
+        Files.write(bagDir.resolve("fetch.txt"), (remoteUrl.toString() + " - data/test.txt\n").getBytes());
+        
+        Bag bag = reader.read(bagDir);
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put(authHeaderName, authHeaderValue);
+        
+        // This should now PASS because Hasher.java strips headers on host change
+        sut.isValid(bag, true, true, headers);
+
+        Assertions.assertFalse(headersSentToServer2.get(), "Headers should NOT have been sent to server2");
+    }
+
+    private String formatMessageDigest(final byte[] digest) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierRedirectTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierRedirectTest.java
@@ -80,7 +80,6 @@ public class BagVerifierRedirectTest extends TempFolderTest {
         server1.createContext("/api/access/datafile/1", new HttpHandler() {
             @Override
             public void handle(HttpExchange exchange) throws IOException {
-                System.out.println("[DEBUG_LOG] Server 1 received request with headers: " + exchange.getRequestHeaders().entrySet());
                 if (authHeaderValue.equals(exchange.getRequestHeaders().getFirst(authHeaderName))) {
                     exchange.getResponseHeaders().set("Location", "http://localhost:" + port2 + "/storage/file1?token=xyz");
                     exchange.sendResponseHeaders(302, -1);
@@ -94,7 +93,6 @@ public class BagVerifierRedirectTest extends TempFolderTest {
         server2.createContext("/storage/file1", new HttpHandler() {
             @Override
             public void handle(HttpExchange exchange) throws IOException {
-                System.out.println("[DEBUG_LOG] Server 2 received request with headers: " + exchange.getRequestHeaders().entrySet());
                 if (exchange.getRequestHeaders().containsKey(authHeaderName)) {
                     headersSentToServer2.set(true);
                     // Simulate 403 Forbidden because S3 rejects requests with unknown/extra auth headers

--- a/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierRemoteTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierRemoteTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2023 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.bagit.verify;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import nl.knaw.dans.bagit.TempFolderTest;
+import nl.knaw.dans.bagit.domain.Bag;
+import nl.knaw.dans.bagit.exceptions.VerificationException;
+import nl.knaw.dans.bagit.reader.BagReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BagVerifierRemoteTest extends TempFolderTest {
+    private HttpServer server;
+    private BagVerifier sut;
+    private BagReader reader;
+    private int port;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        sut = new BagVerifier();
+        reader = new BagReader();
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.setExecutor(null);
+        server.start();
+        port = server.getAddress().getPort();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+        if (sut != null) {
+            sut.close();
+        }
+    }
+
+    @Test
+    public void testIsValidWithExtraHeaders() throws Exception {
+        final String content = "test content";
+        final String authHeader = "SecretToken";
+        
+        server.createContext("/data/test.txt", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                if (authHeader.equals(exchange.getRequestHeaders().getFirst("Authorization"))) {
+                    byte[] response = content.getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(200, response.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(response);
+                    }
+                } else {
+                    exchange.sendResponseHeaders(401, -1);
+                }
+            }
+        });
+
+        Path bagDir = Files.createTempDirectory(folder, "remote-headers-bag");
+        Files.write(bagDir.resolve("bagit.txt"), "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n".getBytes());
+        Files.createDirectory(bagDir.resolve("data"));
+        
+        MessageDigest md5 = MessageDigest.getInstance("MD5");
+        md5.update(content.getBytes(StandardCharsets.UTF_8));
+        String hash = formatMessageDigest(md5.digest());
+        
+        Files.write(bagDir.resolve("manifest-md5.txt"), (hash + "  data/test.txt\n").getBytes());
+        
+        URL remoteUrl = new URL("http://localhost:" + port + "/data/test.txt");
+        Files.write(bagDir.resolve("fetch.txt"), (remoteUrl.toString() + " - data/test.txt\n").getBytes());
+        
+        Bag bag = reader.read(bagDir);
+        
+        // Should fail without headers
+        Assertions.assertThrows(VerificationException.class, () -> sut.isValid(bag, true, true));
+        
+        // Should pass with headers
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", authHeader);
+        sut.isValid(bag, true, true, headers);
+    }
+
+    @Test
+    public void testIsValidWithRedirect() throws Exception {
+        final String content = "redirected content";
+        
+        server.createContext("/redirect", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                exchange.getResponseHeaders().set("Location", "http://localhost:" + port + "/data/final.txt");
+                exchange.sendResponseHeaders(302, -1);
+            }
+        });
+        
+        server.createContext("/data/final.txt", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                byte[] response = content.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, response.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response);
+                }
+            }
+        });
+
+        Path bagDir = Files.createTempDirectory(folder, "remote-redirect-bag");
+        Files.write(bagDir.resolve("bagit.txt"), "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n".getBytes());
+        Files.createDirectory(bagDir.resolve("data"));
+        
+        MessageDigest md5 = MessageDigest.getInstance("MD5");
+        md5.update(content.getBytes(StandardCharsets.UTF_8));
+        String hash = formatMessageDigest(md5.digest());
+        
+        Files.write(bagDir.resolve("manifest-md5.txt"), (hash + "  data/test.txt\n").getBytes());
+        
+        URL redirectUrl = new URL("http://localhost:" + port + "/redirect");
+        Files.write(bagDir.resolve("fetch.txt"), (redirectUrl.toString() + " - data/test.txt\n").getBytes());
+        
+        Bag bag = reader.read(bagDir);
+        
+        sut.isValid(bag, true, true);
+    }
+
+    private String formatMessageDigest(final byte[] digest) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierRemoteTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierRemoteTest.java
@@ -20,7 +20,6 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import nl.knaw.dans.bagit.TempFolderTest;
 import nl.knaw.dans.bagit.domain.Bag;
-import nl.knaw.dans.bagit.exceptions.VerificationException;
 import nl.knaw.dans.bagit.reader.BagReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -37,6 +36,8 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class BagVerifierRemoteTest extends TempFolderTest {
     private HttpServer server;
@@ -56,97 +57,123 @@ public class BagVerifierRemoteTest extends TempFolderTest {
 
     @AfterEach
     public void tearDown() {
-        if (server != null) {
-            server.stop(0);
-        }
-        if (sut != null) {
-            sut.close();
-        }
+        if (server != null) server.stop(0);
+        if (sut != null) sut.close();
     }
 
     @Test
-    public void testIsValidWithExtraHeaders() throws Exception {
-        final String content = "test content";
-        final String authHeader = "SecretToken";
-        
-        server.createContext("/data/test.txt", new HttpHandler() {
+    public void testAuthenticatedRangeRequest() throws Exception {
+        final String content = "this is some test content for range requests";
+        final String authHeaderName = "X-Dataverse-key";
+        final String authHeaderValue = "secret-key";
+        final AtomicInteger rangeRequestCount = new AtomicInteger(0);
+
+        server.createContext("/datafile", new HttpHandler() {
             @Override
             public void handle(HttpExchange exchange) throws IOException {
-                if (authHeader.equals(exchange.getRequestHeaders().getFirst("Authorization"))) {
+                if (!authHeaderValue.equals(exchange.getRequestHeaders().getFirst(authHeaderName))) {
+                    exchange.sendResponseHeaders(401, -1);
+                    return;
+                }
+
+                String range = exchange.getRequestHeaders().getFirst("Range");
+                if (range != null && range.startsWith("bytes=")) {
+                    rangeRequestCount.incrementAndGet();
+                    String[] parts = range.substring(6).split("-");
+                    int start = Integer.parseInt(parts[0]);
+                    int end = Integer.parseInt(parts[1]);
+                    byte[] fullContent = content.getBytes(StandardCharsets.UTF_8);
+                    int actualEnd = Math.min(end, fullContent.length - 1);
+                    int length = actualEnd - start + 1;
+                    
+                    exchange.getResponseHeaders().set("Content-Range", "bytes " + start + "-" + actualEnd + "/" + fullContent.length);
+                    exchange.sendResponseHeaders(206, length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(fullContent, start, length);
+                    }
+                } else {
+                    byte[] response = content.getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(200, response.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(response);
+                    }
+                }
+            }
+        });
+
+        Path bagDir = Files.createTempDirectory(folder, "remote-bag");
+        Files.write(bagDir.resolve("bagit.txt"), "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n".getBytes());
+        Files.createDirectory(bagDir.resolve("data"));
+        
+        MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+        sha1.update(content.getBytes(StandardCharsets.UTF_8));
+        String hash = formatMessageDigest(sha1.digest());
+        
+        Files.write(bagDir.resolve("manifest-sha1.txt"), (hash + "  data/test.txt\n").getBytes());
+        
+        URL remoteUrl = new URL("http://localhost:" + port + "/datafile");
+        Files.write(bagDir.resolve("fetch.txt"), (remoteUrl.toString() + " " + content.length() + " data/test.txt\n").getBytes());
+        
+        Bag bag = reader.read(bagDir);
+        
+        Map<String, String> headers = new HashMap<>();
+        headers.put(authHeaderName, authHeaderValue);
+        
+        // Use a small chunk size to force multiple range requests
+        System.setProperty("nl.knaw.dans.bagit.hash.chunkSize", "10");
+        try {
+            sut.isValid(bag, true, true, headers);
+        } finally {
+            System.clearProperty("nl.knaw.dans.bagit.hash.chunkSize");
+        }
+
+        Assertions.assertTrue(rangeRequestCount.get() > 1, "Should have used multiple range requests, but used: " + rangeRequestCount.get());
+    }
+
+    @Test
+    public void testFallbackToFullDownloadWhenRangeNotSupported() throws Exception {
+        final String content = "this content will be downloaded in one go";
+        final AtomicBoolean rangeAttempted = new AtomicBoolean(false);
+
+        server.createContext("/datafile", new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                if (exchange.getRequestHeaders().containsKey("Range")) {
+                    rangeAttempted.set(true);
+                    // Server ignores range and returns 200 OK
                     byte[] response = content.getBytes(StandardCharsets.UTF_8);
                     exchange.sendResponseHeaders(200, response.length);
                     try (OutputStream os = exchange.getResponseBody()) {
                         os.write(response);
                     }
                 } else {
-                    exchange.sendResponseHeaders(401, -1);
+                    byte[] response = content.getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(200, response.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(response);
+                    }
                 }
             }
         });
 
-        Path bagDir = Files.createTempDirectory(folder, "remote-headers-bag");
+        Path bagDir = Files.createTempDirectory(folder, "remote-bag-fallback");
         Files.write(bagDir.resolve("bagit.txt"), "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n".getBytes());
         Files.createDirectory(bagDir.resolve("data"));
         
-        MessageDigest md5 = MessageDigest.getInstance("MD5");
-        md5.update(content.getBytes(StandardCharsets.UTF_8));
-        String hash = formatMessageDigest(md5.digest());
+        MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+        sha1.update(content.getBytes(StandardCharsets.UTF_8));
+        String hash = formatMessageDigest(sha1.digest());
         
-        Files.write(bagDir.resolve("manifest-md5.txt"), (hash + "  data/test.txt\n").getBytes());
+        Files.write(bagDir.resolve("manifest-sha1.txt"), (hash + "  data/test.txt\n").getBytes());
         
-        URL remoteUrl = new URL("http://localhost:" + port + "/data/test.txt");
-        Files.write(bagDir.resolve("fetch.txt"), (remoteUrl.toString() + " - data/test.txt\n").getBytes());
-        
-        Bag bag = reader.read(bagDir);
-        
-        // Should fail without headers
-        Assertions.assertThrows(VerificationException.class, () -> sut.isValid(bag, true, true));
-        
-        // Should pass with headers
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", authHeader);
-        sut.isValid(bag, true, true, headers);
-    }
-
-    @Test
-    public void testIsValidWithRedirect() throws Exception {
-        final String content = "redirected content";
-        
-        server.createContext("/redirect", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange exchange) throws IOException {
-                exchange.getResponseHeaders().set("Location", "http://localhost:" + port + "/data/final.txt");
-                exchange.sendResponseHeaders(302, -1);
-            }
-        });
-        
-        server.createContext("/data/final.txt", new HttpHandler() {
-            @Override
-            public void handle(HttpExchange exchange) throws IOException {
-                byte[] response = content.getBytes(StandardCharsets.UTF_8);
-                exchange.sendResponseHeaders(200, response.length);
-                try (OutputStream os = exchange.getResponseBody()) {
-                    os.write(response);
-                }
-            }
-        });
-
-        Path bagDir = Files.createTempDirectory(folder, "remote-redirect-bag");
-        Files.write(bagDir.resolve("bagit.txt"), "BagIt-Version: 0.97\nTag-File-Character-Encoding: UTF-8\n".getBytes());
-        Files.createDirectory(bagDir.resolve("data"));
-        
-        MessageDigest md5 = MessageDigest.getInstance("MD5");
-        md5.update(content.getBytes(StandardCharsets.UTF_8));
-        String hash = formatMessageDigest(md5.digest());
-        
-        Files.write(bagDir.resolve("manifest-md5.txt"), (hash + "  data/test.txt\n").getBytes());
-        
-        URL redirectUrl = new URL("http://localhost:" + port + "/redirect");
-        Files.write(bagDir.resolve("fetch.txt"), (redirectUrl.toString() + " - data/test.txt\n").getBytes());
+        URL remoteUrl = new URL("http://localhost:" + port + "/datafile");
+        Files.write(bagDir.resolve("fetch.txt"), (remoteUrl.toString() + " " + content.length() + " data/test.txt\n").getBytes());
         
         Bag bag = reader.read(bagDir);
         
-        sut.isValid(bag, true, true);
+        sut.isValid(bag, true, true, null);
+
+        Assertions.assertTrue(rangeAttempted.get(), "Should have attempted a range request");
     }
 
     private String formatMessageDigest(final byte[] digest) {

--- a/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierTest.java
@@ -16,6 +16,8 @@
 package nl.knaw.dans.bagit.verify;
 
 import java.io.File;
+import java.net.URL;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,6 +35,7 @@ import nl.knaw.dans.bagit.domain.Bag;
 import nl.knaw.dans.bagit.domain.Manifest;
 import nl.knaw.dans.bagit.exceptions.CorruptChecksumException;
 import nl.knaw.dans.bagit.exceptions.FileNotInManifestException;
+import nl.knaw.dans.bagit.exceptions.FileNotInPayloadDirectoryException;
 import nl.knaw.dans.bagit.exceptions.UnsupportedAlgorithmException;
 import nl.knaw.dans.bagit.exceptions.VerificationException;
 import nl.knaw.dans.bagit.hash.StandardSupportedAlgorithms;
@@ -235,5 +238,35 @@ public class BagVerifierTest extends TempFolderTest{
     Bag bag = reader.read(passingRootDir);
     
     BagVerifier.quicklyVerify(bag);
+  }
+
+  @Test
+  public void testHoleyBag() throws Exception {
+    Path bagDir = Paths.get("src", "test", "resources", "md5Bag");
+    Path copyDir = copyBagToTempFolder(bagDir);
+    Path readme = copyDir.resolve("data/readme.txt");
+    byte[] content = Files.readAllBytes(readme);
+    Files.delete(readme);
+
+    // Create a local file to serve as "remote" resource
+    Path remoteFile = copyDir.resolve("remote-readme.txt");
+    Files.write(remoteFile, content);
+    URL remoteUrl = remoteFile.toUri().toURL();
+
+    // Create fetch.txt
+    Path fetchFile = copyDir.resolve("fetch.txt");
+    // Format of fetch.txt: url length path
+    String fetchLine = remoteUrl.toString() + " " + content.length + " data/readme.txt\n";
+    Files.write(fetchFile, fetchLine.getBytes());
+
+    Bag bag = reader.read(copyDir);
+
+    // Should be invalid without isHoley=true because file is missing
+    Assertions.assertThrows(FileNotInPayloadDirectoryException.class, () -> {
+      sut.isValid(bag, true);
+    });
+
+    // Should be valid with isHoley=true
+    sut.isValid(bag, true, true);
   }
 }

--- a/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierTest.java
+++ b/src/test/java/nl/knaw/dans/bagit/verify/BagVerifierTest.java
@@ -256,17 +256,19 @@ public class BagVerifierTest extends TempFolderTest{
     // Create fetch.txt
     Path fetchFile = copyDir.resolve("fetch.txt");
     // Format of fetch.txt: url length path
+    // IMPORTANT: BagReader uses relative paths from root for fetch items, 
+    // but they should NOT have 'data/' prefix if they are in data directory? 
+    // Actually, BagIt spec says it's the path relative to the bag root.
     String fetchLine = remoteUrl.toString() + " " + content.length + " data/readme.txt\n";
     Files.write(fetchFile, fetchLine.getBytes());
 
     Bag bag = reader.read(copyDir);
 
-    // Should be invalid without isHoley=true because file is missing
-    Assertions.assertThrows(FileNotInPayloadDirectoryException.class, () -> {
-      sut.isValid(bag, true);
-    });
+    // With the new logic, it should be valid even without explicitly passing true,
+    // because fetch.txt is present and contains data/readme.txt
+    sut.isValid(bag, true);
 
-    // Should be valid with isHoley=true
+    // It should also be valid if we explicitly pass true
     sut.isValid(bag, true, true);
   }
 }


### PR DESCRIPTION
Fixes DD-2203

# Description of changes
* Extends the `BagVerifier` with a method that allows validation that allows holey bags. In `allowHoley` mode the bag is considered valid even when containing a fetch.txt file provided that the files to be fetched can be validated. When calculating the hashes the files are *not* stored locally. Instead the bytes are streamed through the hasher and discarded. This means very large files can be in the fetch.txt without this requiring the client to maintain a large temp disk. 
* Furthermore, range requests are used if supported. And chunks are retried if the connection is interrupted. The following system properties can be used override the default parameters that control this processed:
  * `nl.knaw.dans.bagit.hash.chunkSize` - number of bytes to read into a chunk.
  * `nl.knaw.dans.bagit.hash.maxRetries` - maximum number of times to try to read a chunk.
  * `nl.knaw.dans.bagit.hash.retrySleepMs` - milliseconds to wait between retries.
* Optional extra headers can be specified to send along with fetch requests, to support fetching items that require authentication. 

## To do

- [x] More robust download using chunks (range-request + retries on fail)
- [x] Support credentials for fetch operations (X-Dataverse-key header)
- [x] Support redirects for fetch operations (direct download from object store) 
- [x] Review + refactor code for readability.
- [x] More logging?
- [x] Test in `dd-validate-bagpack`.

# Notify

@DANS-KNAW/core-systems
